### PR TITLE
fix(BrandEditor): prevent overwriting form values if already populate…

### DIFF
--- a/packages/react-designer/src/components/BrandEditor/BrandEditor.tsx
+++ b/packages/react-designer/src/components/BrandEditor/BrandEditor.tsx
@@ -103,37 +103,42 @@ const BrandEditorComponent = forwardRef<HTMLDivElement, BrandEditorProps>(
     }, [isTenantLoading]);
 
     useEffect(() => {
-      const brandSettings = tenantData?.data?.tenant?.brand?.settings;
-      const paragraphs =
-        brandEditorContent?.split("\n") ?? brandSettings?.email?.footer?.markdown?.split("\n");
-      const findPrefencesUrl = paragraphs?.find((paragraph) =>
-        paragraph.includes("{{urls.preferences}}")
-      );
+      // Only set form values if brandEditorForm is not already populated
+      if (!brandEditorForm) {
+        const brandSettings = tenantData?.data?.tenant?.brand?.settings;
 
-      setBrandEditorForm({
-        brandColor: brandSettings?.colors?.primary || defaultBrandEditorFormValues.brandColor,
-        textColor: brandSettings?.colors?.secondary || defaultBrandEditorFormValues.textColor,
-        subtleColor: brandSettings?.colors?.tertiary || defaultBrandEditorFormValues.subtleColor,
-        headerStyle: brandSettings?.email?.header?.barColor ? "border" : "plain",
-        logo: brandSettings?.email?.header?.logo?.image || defaultBrandEditorFormValues.logo,
-        link: brandSettings?.email?.header?.logo?.href || defaultBrandEditorFormValues.link,
-        facebookLink:
-          brandSettings?.email?.footer?.social?.facebook?.url ||
-          defaultBrandEditorFormValues.facebookLink,
-        linkedinLink:
-          brandSettings?.email?.footer?.social?.linkedin?.url ||
-          defaultBrandEditorFormValues.linkedinLink,
-        instagramLink:
-          brandSettings?.email?.footer?.social?.instagram?.url ||
-          defaultBrandEditorFormValues.instagramLink,
-        mediumLink:
-          brandSettings?.email?.footer?.social?.medium?.url ||
-          defaultBrandEditorFormValues.mediumLink,
-        xLink:
-          brandSettings?.email?.footer?.social?.twitter?.url || defaultBrandEditorFormValues.xLink,
-        isPreferences: Boolean(findPrefencesUrl),
-      });
-    }, [tenantData, setBrandEditorForm, brandEditorContent]);
+        const paragraphs =
+          brandEditorContent?.split("\n") ?? brandSettings?.email?.footer?.markdown?.split("\n");
+        const findPrefencesUrl = paragraphs?.find((paragraph: string) =>
+          paragraph.includes("{{urls.preferences}}")
+        );
+
+        setBrandEditorForm({
+          brandColor: brandSettings?.colors?.primary || defaultBrandEditorFormValues.brandColor,
+          textColor: brandSettings?.colors?.secondary || defaultBrandEditorFormValues.textColor,
+          subtleColor: brandSettings?.colors?.tertiary || defaultBrandEditorFormValues.subtleColor,
+          headerStyle: brandSettings?.email?.header?.barColor ? "border" : "plain",
+          logo: brandSettings?.email?.header?.logo?.image || defaultBrandEditorFormValues.logo,
+          link: brandSettings?.email?.header?.logo?.href || defaultBrandEditorFormValues.link,
+          facebookLink:
+            brandSettings?.email?.footer?.social?.facebook?.url ||
+            defaultBrandEditorFormValues.facebookLink,
+          linkedinLink:
+            brandSettings?.email?.footer?.social?.linkedin?.url ||
+            defaultBrandEditorFormValues.linkedinLink,
+          instagramLink:
+            brandSettings?.email?.footer?.social?.instagram?.url ||
+            defaultBrandEditorFormValues.instagramLink,
+          mediumLink:
+            brandSettings?.email?.footer?.social?.medium?.url ||
+            defaultBrandEditorFormValues.mediumLink,
+          xLink:
+            brandSettings?.email?.footer?.social?.twitter?.url ||
+            defaultBrandEditorFormValues.xLink,
+          isPreferences: Boolean(findPrefencesUrl),
+        });
+      }
+    }, [tenantData, setBrandEditorForm, brandEditorContent, brandEditorForm]);
 
     return (
       <MainLayout theme={theme} isLoading={Boolean(isTenantLoading && isInitialLoadRef.current)}>

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Email/Email.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Email/Email.tsx
@@ -742,10 +742,13 @@ const EmailComponent = forwardRef<HTMLDivElement, EmailProps>(
       }
 
       // At this point, element is guaranteed to be ElementalNode
-      const tipTapContent = convertElementalToTiptap({
-        version: "2022-01-01",
-        elements: [element], // element is now definitely ElementalNode
-      });
+      const tipTapContent = convertElementalToTiptap(
+        {
+          version: "2022-01-01",
+          elements: [element], // element is now definitely ElementalNode
+        },
+        { channel: "email" }
+      );
 
       return tipTapContent;
     }, [templateEditorContent]);

--- a/packages/react-designer/src/components/TemplateEditor/TemplateEditor.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/TemplateEditor.tsx
@@ -7,7 +7,7 @@ import { channelAtom, pageAtom } from "../../store";
 import type { ChannelType } from "../../store";
 import type { BrandEditorProps } from "../BrandEditor";
 import { BrandEditor } from "../BrandEditor";
-import { BrandEditorContentAtom } from "../BrandEditor/store";
+import { BrandEditorContentAtom, BrandEditorFormAtom } from "../BrandEditor/store";
 // import { ElementalValue } from "../ElementalValue/ElementalValue";
 import { useTemplateActions } from "../Providers";
 import {
@@ -61,6 +61,7 @@ const TemplateEditorComponent: React.FC<TemplateEditorProps> = ({
   const isResponseSetRef = useRef(false);
   const [templateEditorContent, setTemplateEditorContent] = useAtom(templateEditorContentAtom);
   const setBrandEditorContent = useSetAtom(BrandEditorContentAtom);
+  const setBrandEditorForm = useSetAtom(BrandEditorFormAtom);
   const [channel, setChannel] = useAtom(channelAtom);
 
   useEffect(() => {
@@ -94,6 +95,7 @@ const TemplateEditorComponent: React.FC<TemplateEditorProps> = ({
       setTenantData(null);
       setTemplateEditorContent(null);
       setBrandEditorContent(null);
+      setBrandEditorForm(null);
       setSubject(null);
       setChannel(channels?.[0] || "email");
       isResponseSetRef.current = false;
@@ -109,6 +111,7 @@ const TemplateEditorComponent: React.FC<TemplateEditorProps> = ({
     setSubject,
     setTenantData,
     setBrandEditorContent,
+    setBrandEditorForm,
     setChannel,
   ]);
 

--- a/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.test.tsx
+++ b/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.test.tsx
@@ -782,4 +782,107 @@ describe("convertElementalToTiptap", () => {
       )
     ).toBe(true);
   });
+
+  it("should convert consecutive action nodes to ButtonRow for inbox channel", () => {
+    const elemental: ElementalContent = {
+      version: "2022-01-01",
+      elements: [
+        {
+          type: "channel",
+          channel: "inbox",
+          elements: [
+            {
+              type: "action",
+              content: "Primary Button",
+              href: "https://primary.com",
+              background_color: "#000000",
+              color: "#ffffff",
+            },
+            {
+              type: "action",
+              content: "Secondary Button",
+              href: "https://secondary.com",
+              background_color: "#ffffff",
+              color: "#000000",
+            },
+          ],
+        } as any,
+      ],
+    };
+
+    const result = convertElementalToTiptap(elemental, { channel: "inbox" });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toMatchObject({
+      type: "buttonRow",
+      attrs: expect.objectContaining({
+        button1Label: "Primary Button",
+        button1Link: "https://primary.com",
+        button1BackgroundColor: "#000000",
+        button1TextColor: "#ffffff",
+        button2Label: "Secondary Button",
+        button2Link: "https://secondary.com",
+        button2BackgroundColor: "#ffffff",
+        button2TextColor: "#000000",
+      }),
+    });
+  });
+
+  it("should NOT convert consecutive action nodes to ButtonRow for email channel", () => {
+    const elemental = createElementalContent([
+      {
+        type: "action",
+        content: "Primary Button",
+        href: "https://primary.com",
+        background_color: "#000000",
+        color: "#ffffff",
+      },
+      {
+        type: "action",
+        content: "Secondary Button",
+        href: "https://secondary.com",
+        background_color: "#ffffff",
+        color: "#000000",
+      },
+    ]);
+
+    const result = convertElementalToTiptap(elemental, { channel: "email" });
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0]).toMatchObject({
+      type: "button",
+      attrs: expect.objectContaining({
+        label: "Primary Button",
+        link: "https://primary.com",
+      }),
+    });
+    expect(result.content[1]).toMatchObject({
+      type: "button",
+      attrs: expect.objectContaining({
+        label: "Secondary Button",
+        link: "https://secondary.com",
+      }),
+    });
+  });
+
+  it("should NOT convert consecutive action nodes to ButtonRow when no channel is specified", () => {
+    const elemental = createElementalContent([
+      {
+        type: "action",
+        content: "Primary Button",
+        href: "https://primary.com",
+      },
+      {
+        type: "action",
+        content: "Secondary Button",
+        href: "https://secondary.com",
+      },
+    ]);
+
+    const result = convertElementalToTiptap(elemental);
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0].type).toBe("button");
+    expect(result.content[1].type).toBe("button");
+  });
 });

--- a/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
+++ b/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
@@ -479,7 +479,7 @@ export function convertElementalToTiptap(
     }
   };
 
-  // Process elements to convert consecutive action nodes to ButtonRow
+  // Process elements to convert consecutive action nodes to ButtonRow (only for Inbox channel)
   const processedElements: TiptapNode[] = [];
   const convertedNodes = targetChannelElements.flatMap(convertNode);
 
@@ -487,8 +487,12 @@ export function convertElementalToTiptap(
     const currentNode = convertedNodes[i];
     const nextNode = convertedNodes[i + 1];
 
-    // Check if current and next nodes are both buttons (action nodes)
-    if (currentNode.type === "button" && nextNode?.type === "button") {
+    // Check if current and next nodes are both buttons (action nodes) and we're in the inbox channel
+    if (
+      currentNode.type === "button" &&
+      nextNode?.type === "button" &&
+      specifiedChannelName === "inbox"
+    ) {
       // Convert to ButtonRow, preserving the original button styles from the sidebar settings
       const buttonRowNode: TiptapNode = {
         type: "buttonRow",


### PR DESCRIPTION
…d; update TemplateEditor to clear brand editor form on reset

## Description of changes

This PR fixes the Brand's state sync issue between Brand Editor and Template Editor

## Checklist

Before merging to main:

- [ ] Tests
- [x] Changes have been manually tested
- [ ] Changeset added (if needed for publishing)
- [ ] PR has been approved 