### PR TITLE
[C-17554] Adjust fonts feature copy and tooltips

### DIFF
--- a/packages/react-designer/src/components/TemplateEditor/Channels/Email/EmailLayout.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Email/EmailLayout.tsx
@@ -300,7 +300,25 @@ export const EmailLayout = ({
                           <>
                             <h4 className="courier-text-sm courier-font-medium courier-mb-3 courier-flex courier-items-center">
                               <span>Font</span>
-                              <Tooltip title="Google Fonts are loaded from Google's CDN. They render in clients that support web fonts. Other clients display the fallback font instead.">
+                              <Tooltip
+                                title={
+                                  <>
+                                    The font is applied to all text in your email. Choose from
+                                    email-safe fonts that work everywhere, or Google Fonts for more
+                                    variety (supported in Apple Mail, iOS Mail, and some Android
+                                    clients).{" "}
+                                    <a
+                                      href="https://www.courier.com/docs/platform/content/elemental/custom-fonts#email-client-support"
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="courier-underline courier-underline-offset-2"
+                                    >
+                                      Learn more
+                                    </a>
+                                  </>
+                                }
+                                tippyOptions={{ maxWidth: 260, interactive: true }}
+                              >
                                 <Info className="courier-ml-1.5 courier-h-3.5 courier-w-3.5 courier-text-muted-foreground courier-cursor-help" />
                               </Tooltip>
                             </h4>
@@ -313,7 +331,22 @@ export const EmailLayout = ({
                             />
                             <h4 className="courier-text-sm courier-font-medium courier-mb-3 courier-flex courier-items-center">
                               <span>Font fallback</span>
-                              <Tooltip title="Used when the primary font can't load. Pick an email-safe font that works in all clients.">
+                              <Tooltip
+                                title={
+                                  <>
+                                    {`If the recipient's email client doesn't support your chosen font, this font will be used instead. We recommend Arial, Verdana, or Georgia for the best compatibility. `}
+                                    <a
+                                      href="https://www.courier.com/docs/platform/content/elemental/custom-fonts#email-client-support"
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="courier-underline courier-underline-offset-2"
+                                    >
+                                      Learn more
+                                    </a>
+                                  </>
+                                }
+                                tippyOptions={{ maxWidth: 260, interactive: true }}
+                              >
                                 <Info className="courier-ml-1.5 courier-h-3.5 courier-w-3.5 courier-text-muted-foreground courier-cursor-help" />
                               </Tooltip>
                             </h4>
@@ -324,17 +357,6 @@ export const EmailLayout = ({
                               onChange={handleFallbackChange}
                               className="courier-mb-3"
                             />
-                            <p className="courier-text-xs courier-text-muted-foreground courier-mb-3 courier-leading-relaxed">
-                              Most email clients don&apos;t support custom fonts.{" "}
-                              <a
-                                href="https://www.courier.com/docs/platform/content/elemental/custom-fonts#email-client-support"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="courier-inline-flex courier-items-center courier-gap-0.5 courier-text-muted-foreground hover:courier-text-foreground courier-underline courier-underline-offset-2"
-                              >
-                                See supported clients ↗
-                              </a>
-                            </p>
                           </>
                         )}
                       </TabsContent>

--- a/packages/react-designer/src/components/ui/Tooltip/index.tsx
+++ b/packages/react-designer/src/components/ui/Tooltip/index.tsx
@@ -34,6 +34,7 @@ export const Tooltip = ({
   tippyOptions = {},
 }: TooltipProps): JSX.Element => {
   const theme = useTheme();
+  const { maxWidth, ...restTippyOptions } = tippyOptions;
 
   const renderTooltip = useCallback(
     (attrs: TippyProps) => {
@@ -51,7 +52,7 @@ export const Tooltip = ({
             "courier-flex courier-items-center courier-gap-2 courier-px-2.5 courier-py-1 courier-bg-popover courier-text-popover-foreground courier-border courier-border-border courier-rounded-lg courier-shadow-sm courier-z-[999]",
             theme.colorScheme === "dark" ? "dark" : ""
           )}
-          style={cssVars as CSSProperties}
+          style={{ ...cssVars, ...(maxWidth != null && { maxWidth }) } as CSSProperties}
           tabIndex={-1}
           data-placement={attrs["data-placement"]}
           data-reference-hidden={attrs["data-reference-hidden"]}
@@ -72,7 +73,7 @@ export const Tooltip = ({
         </span>
       );
     },
-    [shortcut, title, theme]
+    [shortcut, title, theme, maxWidth]
   );
 
   // Use a callback ref with state to avoid React 19 warning about element.ref
@@ -86,7 +87,6 @@ export const Tooltip = ({
         <span ref={setReferenceElement}>{children}</span>
         {referenceElement && (
           <Tippy
-            {...tippyOptions}
             delay={500}
             offset={[0, 8]}
             touch={false}
@@ -94,8 +94,9 @@ export const Tooltip = ({
             appendTo={document.body}
             trigger="mouseenter focus"
             showOnCreate={false}
-            render={renderTooltip}
             animation={false}
+            {...restTippyOptions}
+            render={renderTooltip}
             reference={referenceElement}
           />
         )}


### PR DESCRIPTION
## Summary
- Removes the "Most email clients don't support custom fonts" warning from the email styles side panel (was too alarming)
- Updates the **Font** tooltip with descriptive copy about email-safe and Google Fonts support
- Updates the **Font fallback** tooltip with guidance on fallback font selection
- Adds "Learn more" doc links to both tooltips pointing to the custom fonts documentation

## Linear
https://linear.app/trycourier/issue/C-17554/adjustments-to-fonts-feature-copies

## Test plan
- [ ] Open email template editor with custom fonts enabled
- [ ] Verify the font compatibility warning is no longer visible in the side panel
- [ ] Hover over the Font info icon and verify the new tooltip text and "Learn more" link
- [ ] Hover over the Font fallback info icon and verify the new tooltip text and "Learn more" link
- [ ] Click "Learn more" links and verify they open the correct docs page

Made with [Cursor](https://cursor.com)