### PR TITLE
[C-17646] Add merge governance baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Courier Designer CODEOWNERS
+# Auto-assignment only; approval enforcement is handled by rulesets.
+
+*                                   @trycourier/frontend
+
+/packages/                          @sashathor @gerjunior
+/.github/workflows/                 @sashathor @gerjunior

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,28 @@
-## Description of changes
+## Description
 
-This PR…
+<!-- What changed and why -->
 
-## Checklist
+## Type of change
 
-Before merging to main:
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Config/infra change
+- [ ] Docs or guidelines
 
-- [ ] Tests
+## Test Plan
+
+<!-- Required. How was this tested? -->
+
+## Risk
+
+<!-- GREEN / YELLOW / ORANGE / RED -->
+
+## Related issues
+
+<!-- Link Linear tickets: e.g. Closes C-12345 -->
+
+## Additional checklist
+
 - [ ] Changes have been manually tested
 - [ ] Changeset added (if needed for publishing)
-- [ ] PR has been approved

--- a/.github/workflows/auto-approve-docs.yml
+++ b/.github/workflows/auto-approve-docs.yml
@@ -1,0 +1,20 @@
+name: Auto-approve doc-only PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-approve-docs:
+    uses: trycourier/github-workflows/.github/workflows/auto-approve-docs.yml@v1
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      docs_prefixes_json: '["docs/"]'
+      docs_extensions_json: '[".md"]'
+      skip_draft_prs: true

--- a/.github/workflows/risk-tier-policy.yml
+++ b/.github/workflows/risk-tier-policy.yml
@@ -1,0 +1,26 @@
+name: Risk Tier Policy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, edited, auto_merge_enabled, auto_merge_disabled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  risk-tier-policy:
+    uses: trycourier/github-workflows/.github/workflows/risk-tier-policy.yml@v1
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    with:
+      red_exact_json: '[]'
+      red_prefixes_json: '[".github/workflows/"]'
+      orange_prefixes_json: '["packages/"]'
+      green_prefixes_json: '["docs/", ".changeset/"]'
+      green_extensions_json: '[".md", ".snap"]'
+      enforce_red_no_auto_merge: true
+      manage_risk_labels: true


### PR DESCRIPTION
## Summary\n- add CODEOWNERS for review auto-assignment\n- standardize PR template with Test Plan + Risk\n- adopt shared governance workflows (auto-approve-docs + risk-tier-policy) from trycourier/github-workflows@v1\n\n## Risk\nRED — touches governance workflow/config files only.\n\nCloses C-17646