### PR TITLE
fix: add renderToaster prop to prevent duplicate toasts when embedded

### DIFF
--- a/packages/react-designer/src/components/Providers/TemplateProvider.tsx
+++ b/packages/react-designer/src/components/Providers/TemplateProvider.tsx
@@ -2,7 +2,14 @@ import { Provider, useAtom, createStore, useStore } from "jotai";
 import { createContext, memo, useContext, useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import type { BasicProviderProps, UploadImageFunction } from "./Providers.types";
-import { apiUrlAtom, templateErrorAtom, templateIdAtom, tenantIdAtom, tokenAtom } from "./store";
+import {
+  apiUrlAtom,
+  renderToasterAtom,
+  templateErrorAtom,
+  templateIdAtom,
+  tenantIdAtom,
+  tokenAtom,
+} from "./store";
 import {
   availableVariablesAtom,
   disableVariablesAutocompleteAtom,
@@ -38,6 +45,12 @@ type TemplateProviderProps = BasicProviderProps & {
   variableValidation?: VariableValidationConfig;
   // Sample data payload for validating loop data paths
   sampleData?: Record<string, unknown>;
+  /**
+   * Whether the designer should render its own Sonner `<Toaster />`.
+   * Set to `false` when the host app already provides one to avoid duplicate toasts.
+   * @default true
+   */
+  renderToaster?: boolean;
 };
 
 // Internal component that uses atoms
@@ -52,6 +65,7 @@ const TemplateProviderContext: React.FC<TemplateProviderProps> = ({
   disableVariablesAutocomplete = false,
   variableValidation,
   sampleData,
+  renderToaster = true,
 }) => {
   const [, setApiUrl] = useAtom(apiUrlAtom);
   const [, setToken] = useAtom(tokenAtom);
@@ -63,6 +77,7 @@ const TemplateProviderContext: React.FC<TemplateProviderProps> = ({
   const [, setVariablesEnabled] = useAtom(variablesEnabledAtom);
   const [, setVariableValidation] = useAtom(variableValidationAtom);
   const [, setSampleData] = useAtom(sampleDataAtom);
+  const [, setRenderToaster] = useAtom(renderToasterAtom);
 
   // Set configuration on mount
   useEffect(() => {
@@ -73,6 +88,10 @@ const TemplateProviderContext: React.FC<TemplateProviderProps> = ({
       setApiUrl(apiUrl);
     }
   }, [token, tenantId, templateId, apiUrl, setApiUrl, setToken, setTenantId, setId]);
+
+  useEffect(() => {
+    setRenderToaster(renderToaster);
+  }, [renderToaster, setRenderToaster]);
 
   // Sync variables for autocomplete
   useEffect(() => {

--- a/packages/react-designer/src/components/Providers/store.ts
+++ b/packages/react-designer/src/components/Providers/store.ts
@@ -121,6 +121,7 @@ export const isTemplateSavingAtom = atom<boolean | null>(null);
 export const isTemplatePublishingAtom = atom<boolean | null>(null);
 export const templateErrorAtom = atom<TemplateError | null>(null);
 export const brandApplyAtom = atom<boolean>(true);
+export const renderToasterAtom = atom<boolean>(true);
 
 // Types for template actions
 export interface TemplateActions {

--- a/packages/react-designer/src/components/ui/MainLayout/MainLayout.tsx
+++ b/packages/react-designer/src/components/ui/MainLayout/MainLayout.tsx
@@ -5,7 +5,7 @@ import { forwardRef, type HTMLAttributes } from "react";
 import { useAtomValue } from "jotai";
 import { Toaster } from "sonner";
 import { Loader } from "../Loader";
-import { brandColorsAtom } from "@/components/Providers/store";
+import { brandColorsAtom, renderToasterAtom } from "@/components/Providers/store";
 import { brandColorsToCSSVars } from "@/lib/utils/brandColors";
 
 export interface MainLayoutProps extends HTMLAttributes<HTMLDivElement> {
@@ -45,32 +45,38 @@ const BrandColorVarsWrapper = ({
 };
 
 export const MainLayout = forwardRef<HTMLDivElement, MainLayoutProps>(
-  ({ theme, children, isLoading, Header, colorScheme, className, readOnly, ...rest }, ref) => (
-    <ThemeProvider theme={theme} ref={ref} colorScheme={colorScheme} className={className}>
-      <BrandColorVarsWrapper readOnly={readOnly} {...rest}>
-        {Header && (
-          <div className="courier-main-header courier-flex courier-flex-row courier-h-12 courier-flex-shrink-0 courier-w-full courier-bg-primary courier-border-b courier-px-4 courier-items-center courier-gap-4 courier-self-stretch dark:courier-bg-background">
-            {Header}
-          </div>
-        )}
-        {isLoading && (
-          <div className="courier-editor-loading">
-            <Loader />
-          </div>
-        )}
-        <Toaster
-          position="top-center"
-          expand
-          visibleToasts={2}
-          style={{
-            position: "absolute",
-            top: "10px",
-            left: "50%",
-            transform: "translateX(-50%)",
-          }}
-        />
-        {children}
-      </BrandColorVarsWrapper>
-    </ThemeProvider>
-  )
+  ({ theme, children, isLoading, Header, colorScheme, className, readOnly, ...rest }, ref) => {
+    const showToaster = useAtomValue(renderToasterAtom);
+
+    return (
+      <ThemeProvider theme={theme} ref={ref} colorScheme={colorScheme} className={className}>
+        <BrandColorVarsWrapper readOnly={readOnly} {...rest}>
+          {Header && (
+            <div className="courier-main-header courier-flex courier-flex-row courier-h-12 courier-flex-shrink-0 courier-w-full courier-bg-primary courier-border-b courier-px-4 courier-items-center courier-gap-4 courier-self-stretch dark:courier-bg-background">
+              {Header}
+            </div>
+          )}
+          {isLoading && (
+            <div className="courier-editor-loading">
+              <Loader />
+            </div>
+          )}
+          {showToaster && (
+            <Toaster
+              position="top-center"
+              expand
+              visibleToasts={2}
+              style={{
+                position: "absolute",
+                top: "10px",
+                left: "50%",
+                transform: "translateX(-50%)",
+              }}
+            />
+          )}
+          {children}
+        </BrandColorVarsWrapper>
+      </ThemeProvider>
+    );
+  }
 );


### PR DESCRIPTION
## Summary
- Adds a `renderToaster` prop to `TemplateProvider` (default `true`) that controls whether the designer renders its own Sonner `<Toaster />`
- When the host app (e.g. Studio) already provides a global Toaster, it can pass `renderToaster={false}` to avoid every `toast()` call appearing twice
- Not a breaking change — standalone usage is unchanged

## Root cause
Studio's `_app.tsx` mounts a global `<Toaster />` from Sonner. The designer's `MainLayout` mounts its own. Since Sonner dispatches toasts to **all** mounted `<Toaster />` instances, every `toast.success()` / `toast.error()` call renders in both, producing duplicate toasts on CDS pages.

## Changes
| File | Change |
|------|--------|
| `Providers/store.ts` | Add `renderToasterAtom` (default `true`) |
| `Providers/TemplateProvider.tsx` | Add `renderToaster` prop, sync to atom |
| `ui/MainLayout/MainLayout.tsx` | Read atom, conditionally render `<Toaster />` |

## Test plan
- [ ] Publish a template on a CDS page in Studio with `renderToaster={false}` — single toast
- [ ] Use the designer standalone (editor-dev) — toasts still work (default `true`)
- [ ] Variable validation errors still show as toasts in both modes


Made with [Cursor](https://cursor.com)