### PR TITLE
feat: add "Open link in new tab" toggle for inbox action buttons

### DIFF
--- a/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/SideBar/SideBar.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/SideBar/SideBar.tsx
@@ -31,9 +31,11 @@ const buttonFormSchema = z.object({
   enableButton: z.boolean().default(true),
   buttonLabel: z.string().default("Enter text"),
   buttonUrl: z.string().default(""),
+  buttonOpenInNewTab: z.boolean().default(false),
   enableSecondaryButton: z.boolean().default(false),
   secondaryButtonLabel: z.string().default("Enter text"),
   secondaryButtonUrl: z.string().default(""),
+  secondaryButtonOpenInNewTab: z.boolean().default(false),
 });
 
 type ButtonFormValues = z.infer<typeof buttonFormSchema>;
@@ -56,9 +58,11 @@ const SideBarComponent = () => {
       enableButton: false,
       buttonLabel: "Enter text",
       buttonUrl: "",
+      buttonOpenInNewTab: false,
       enableSecondaryButton: false,
       secondaryButtonLabel: "Enter text",
       secondaryButtonUrl: "",
+      secondaryButtonOpenInNewTab: false,
     },
     mode: "onChange",
   });
@@ -113,11 +117,19 @@ const SideBarComponent = () => {
         if (currentValues.buttonUrl !== (button1Link || "")) {
           form.setValue("buttonUrl", button1Link || "", { shouldDirty: false });
         }
+        const b1NewTab = (buttonRowAttrs as ButtonRowProps).button1OpenInNewTab ?? false;
+        if (currentValues.buttonOpenInNewTab !== b1NewTab) {
+          form.setValue("buttonOpenInNewTab", b1NewTab, { shouldDirty: false });
+        }
         if (!currentValues.enableSecondaryButton) {
           form.setValue("enableSecondaryButton", true, { shouldDirty: false });
         }
         if (currentValues.secondaryButtonUrl !== (button2Link || "")) {
           form.setValue("secondaryButtonUrl", button2Link || "", { shouldDirty: false });
+        }
+        const b2NewTab = (buttonRowAttrs as ButtonRowProps).button2OpenInNewTab ?? false;
+        if (currentValues.secondaryButtonOpenInNewTab !== b2NewTab) {
+          form.setValue("secondaryButtonOpenInNewTab", b2NewTab, { shouldDirty: false });
         }
       } else if (singleButtonAttrs.length > 0) {
         const primary = singleButtonAttrs[0];
@@ -127,6 +139,10 @@ const SideBarComponent = () => {
         }
         if (currentValues.buttonUrl !== ((primary.link as string) || "")) {
           form.setValue("buttonUrl", (primary.link as string) || "", { shouldDirty: false });
+        }
+        const pNewTab = (primary.openInNewTab as boolean) ?? false;
+        if (currentValues.buttonOpenInNewTab !== pNewTab) {
+          form.setValue("buttonOpenInNewTab", pNewTab, { shouldDirty: false });
         }
 
         if (singleButtonAttrs.length > 1) {
@@ -139,6 +155,10 @@ const SideBarComponent = () => {
               shouldDirty: false,
             });
           }
+          const sNewTab = (secondary.openInNewTab as boolean) ?? false;
+          if (currentValues.secondaryButtonOpenInNewTab !== sNewTab) {
+            form.setValue("secondaryButtonOpenInNewTab", sNewTab, { shouldDirty: false });
+          }
         } else {
           if (currentValues.enableSecondaryButton) {
             form.setValue("enableSecondaryButton", false, { shouldDirty: false });
@@ -149,9 +169,11 @@ const SideBarComponent = () => {
           enableButton: false,
           buttonLabel: "Enter text",
           buttonUrl: "",
+          buttonOpenInNewTab: false,
           enableSecondaryButton: false,
           secondaryButtonLabel: "Enter text",
           secondaryButtonUrl: "",
+          secondaryButtonOpenInNewTab: false,
         });
       }
 
@@ -189,17 +211,19 @@ const SideBarComponent = () => {
     );
 
     if (actionElements.length > 0) {
-      const primaryButton = actionElements[0];
-      const secondaryButton = actionElements[1];
+      const primaryButton = actionElements[0] as ElementalActionNode;
+      const secondaryButton = actionElements[1] as ElementalActionNode | undefined;
 
       form.setValue("enableButton", true);
       form.setValue("buttonLabel", primaryButton.content || "Enter text");
       form.setValue("buttonUrl", primaryButton.href || "");
+      form.setValue("buttonOpenInNewTab", primaryButton.open_in_new_tab ?? false);
 
       if (secondaryButton) {
         form.setValue("enableSecondaryButton", true);
         form.setValue("secondaryButtonLabel", secondaryButton.content || "Enter text");
         form.setValue("secondaryButtonUrl", secondaryButton.href || "");
+        form.setValue("secondaryButtonOpenInNewTab", secondaryButton.open_in_new_tab ?? false);
       } else {
         form.setValue("enableSecondaryButton", false);
       }
@@ -251,6 +275,7 @@ const SideBarComponent = () => {
           border: { enabled: true, color: "#000000", radius: 4, size: "1px" },
           align: "left",
           href: values.buttonUrl,
+          ...(values.buttonOpenInNewTab && { open_in_new_tab: true }),
         };
         newElements.push(primaryAction);
       }
@@ -262,6 +287,7 @@ const SideBarComponent = () => {
           border: { enabled: true, color: "#000000", radius: 4, size: "1px" },
           align: "left",
           href: values.secondaryButtonUrl,
+          ...(values.secondaryButtonOpenInNewTab && { open_in_new_tab: true }),
         };
         newElements.push(secondaryAction);
       }
@@ -342,8 +368,10 @@ const SideBarComponent = () => {
           ...node.attrs,
           button1Label: values.buttonLabel,
           button1Link: values.buttonUrl,
+          button1OpenInNewTab: values.buttonOpenInNewTab,
           button2Label: values.secondaryButtonLabel,
           button2Link: values.secondaryButtonUrl,
+          button2OpenInNewTab: values.secondaryButtonOpenInNewTab,
         };
         return applyAttrs(buttonRowPos, updatedAttrs);
       }
@@ -354,6 +382,7 @@ const SideBarComponent = () => {
           ...primary.attrs,
           label: values.buttonLabel,
           link: values.buttonUrl,
+          openInNewTab: values.buttonOpenInNewTab,
         };
         const updatedPrimary = applyAttrs(primary.pos, primaryAttrs);
         let updatedSecondary = true;
@@ -362,6 +391,7 @@ const SideBarComponent = () => {
             ...secondary.attrs,
             label: values.secondaryButtonLabel,
             link: values.secondaryButtonUrl,
+            openInNewTab: values.secondaryButtonOpenInNewTab,
           };
           updatedSecondary = applyAttrs(secondary.pos, secondaryAttrs);
         }
@@ -383,7 +413,9 @@ const SideBarComponent = () => {
       const structuralChange =
         !previous ||
         previous.enableButton !== values.enableButton ||
-        previous.enableSecondaryButton !== values.enableSecondaryButton;
+        previous.enableSecondaryButton !== values.enableSecondaryButton ||
+        previous.buttonOpenInNewTab !== values.buttonOpenInNewTab ||
+        previous.secondaryButtonOpenInNewTab !== values.secondaryButtonOpenInNewTab;
 
       if (structuralChange) {
         updateButtonInEditor(values);
@@ -408,7 +440,12 @@ const SideBarComponent = () => {
       if (name === "buttonLabel" || name === "secondaryButtonLabel") return;
       const values = form.getValues();
 
-      if (name === "enableButton" || name === "enableSecondaryButton") {
+      if (
+        name === "enableButton" ||
+        name === "enableSecondaryButton" ||
+        name === "buttonOpenInNewTab" ||
+        name === "secondaryButtonOpenInNewTab"
+      ) {
         handleFormUpdate(values);
         debouncedUpdate(values);
       } else if (name) {
@@ -467,7 +504,7 @@ const SideBarComponent = () => {
               control={form.control}
               name="buttonUrl"
               render={({ field }) => (
-                <FormItem className="courier-mb-6">
+                <FormItem className="courier-mb-4">
                   <FormLabel>Action URL</FormLabel>
                   <FormControl>
                     <VariableTextarea
@@ -480,6 +517,22 @@ const SideBarComponent = () => {
                     />
                   </FormControl>
                   <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="buttonOpenInNewTab"
+              render={({ field }) => (
+                <FormItem className="courier-flex courier-flex-row courier-items-center courier-justify-between courier-mb-6">
+                  <FormLabel className="!courier-m-0">Open link in new tab</FormLabel>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      className="!courier-m-0"
+                    />
+                  </FormControl>
                 </FormItem>
               )}
             />
@@ -544,6 +597,22 @@ const SideBarComponent = () => {
                     />
                   </FormControl>
                   <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="secondaryButtonOpenInNewTab"
+              render={({ field }) => (
+                <FormItem className="courier-flex courier-flex-row courier-items-center courier-justify-between courier-mb-4">
+                  <FormLabel className="!courier-m-0">Open link in new tab</FormLabel>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      className="!courier-m-0"
+                    />
+                  </FormControl>
                 </FormItem>
               )}
             />

--- a/packages/react-designer/src/components/extensions/Button/Button.ts
+++ b/packages/react-designer/src/components/extensions/Button/Button.ts
@@ -173,6 +173,13 @@ export const Button = Node.create({
           "data-node-id": attributes.id,
         }),
       },
+      openInNewTab: {
+        default: false,
+        parseHTML: (element) => element.getAttribute("data-open-in-new-tab") === "true",
+        renderHTML: (attributes) => ({
+          "data-open-in-new-tab": attributes.openInNewTab ? "true" : undefined,
+        }),
+      },
       locales: {
         default: undefined,
         parseHTML: () => undefined,

--- a/packages/react-designer/src/components/extensions/Button/Button.types.ts
+++ b/packages/react-designer/src/components/extensions/Button/Button.types.ts
@@ -12,6 +12,7 @@ export const buttonSchema = z.object({
   fontStyle: z.enum(["normal", "italic"]),
   isUnderline: z.boolean(),
   isStrike: z.boolean(),
+  openInNewTab: z.boolean().optional(),
   // Legacy properties - kept for backward compatibility but not editable in UI
   textColor: z.string().optional(),
   borderColor: z.string().optional(),
@@ -29,6 +30,7 @@ export interface ButtonProps {
   fontStyle: "normal" | "italic";
   isUnderline: boolean;
   isStrike: boolean;
+  openInNewTab?: boolean;
   /** @deprecated Legacy property - not supported by Elemental */
   textColor?: string;
   /** @deprecated Legacy property - not supported by Elemental */

--- a/packages/react-designer/src/components/extensions/ButtonRow/ButtonRow.ts
+++ b/packages/react-designer/src/components/extensions/ButtonRow/ButtonRow.ts
@@ -72,6 +72,13 @@ export const ButtonRow = Node.create({
         parseHTML: () => undefined,
         renderHTML: () => ({}),
       },
+      button1OpenInNewTab: {
+        default: false,
+        parseHTML: (element) => element.getAttribute("data-button1-open-in-new-tab") === "true",
+        renderHTML: (attributes) => ({
+          "data-button1-open-in-new-tab": attributes.button1OpenInNewTab ? "true" : undefined,
+        }),
+      },
       button2Label: {
         default: defaultButtonRowProps.button2Label,
         parseHTML: (element) => element.getAttribute("data-button2-label"),
@@ -101,6 +108,13 @@ export const ButtonRow = Node.create({
         default: undefined,
         parseHTML: () => undefined,
         renderHTML: () => ({}),
+      },
+      button2OpenInNewTab: {
+        default: false,
+        parseHTML: (element) => element.getAttribute("data-button2-open-in-new-tab") === "true",
+        renderHTML: (attributes) => ({
+          "data-button2-open-in-new-tab": attributes.button2OpenInNewTab ? "true" : undefined,
+        }),
       },
       padding: {
         default: defaultButtonRowProps.padding,

--- a/packages/react-designer/src/components/extensions/ButtonRow/ButtonRow.types.ts
+++ b/packages/react-designer/src/components/extensions/ButtonRow/ButtonRow.types.ts
@@ -8,12 +8,14 @@ export interface ButtonRowProps {
   button1TextColor: string;
   button1If?: unknown;
   button1Locales?: unknown;
+  button1OpenInNewTab?: boolean;
   button2Label: string;
   button2Link: string;
   button2BackgroundColor: string;
   button2TextColor: string;
   button2If?: unknown;
   button2Locales?: unknown;
+  button2OpenInNewTab?: boolean;
   padding?: number;
 }
 

--- a/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
+++ b/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
@@ -655,6 +655,7 @@ export function convertElementalToTiptap(
               ...(borderColor && { borderColor }), // Legacy backward compat
               ...(node.locales && { locales: node.locales }),
               ...(node.if !== undefined && { if: node.if }),
+              ...(node.open_in_new_tab && { openInNewTab: true }),
             },
           },
         ];
@@ -1417,12 +1418,14 @@ export function convertElementalToTiptap(
           button1TextColor: currentNode.attrs?.textColor || "#ffffff",
           ...(currentNode.attrs?.if !== undefined ? { button1If: currentNode.attrs.if } : {}),
           ...(currentNode.attrs?.locales ? { button1Locales: currentNode.attrs.locales } : {}),
+          ...(currentNode.attrs?.openInNewTab ? { button1OpenInNewTab: true } : {}),
           button2Label: nextNode.attrs?.label || "Button 2",
           button2Link: nextNode.attrs?.link || "",
           button2BackgroundColor: nextNode.attrs?.backgroundColor || "#ffffff",
           button2TextColor: nextNode.attrs?.textColor || "#000000",
           ...(nextNode.attrs?.if !== undefined ? { button2If: nextNode.attrs.if } : {}),
           ...(nextNode.attrs?.locales ? { button2Locales: nextNode.attrs.locales } : {}),
+          ...(nextNode.attrs?.openInNewTab ? { button2OpenInNewTab: true } : {}),
           padding: currentNode.attrs?.paddingVertical || 8,
         },
       };

--- a/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts
+++ b/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts
@@ -578,6 +578,10 @@ export function convertTiptapToElemental(tiptap: TiptapDoc): ElementalNode[] {
           actionNode.if = node.attrs.if as ElementalActionNode["if"];
         }
 
+        if (node.attrs?.openInNewTab) {
+          actionNode.open_in_new_tab = true;
+        }
+
         return [actionNode];
       }
 
@@ -604,6 +608,9 @@ export function convertTiptapToElemental(tiptap: TiptapDoc): ElementalNode[] {
         if (node.attrs?.button1If !== undefined) {
           button1Node.if = node.attrs.button1If as ElementalActionNode["if"];
         }
+        if (node.attrs?.button1OpenInNewTab) {
+          button1Node.open_in_new_tab = true;
+        }
 
         const button2Node: ElementalActionNode = {
           type: "action",
@@ -625,6 +632,9 @@ export function convertTiptapToElemental(tiptap: TiptapDoc): ElementalNode[] {
         }
         if (node.attrs?.button2If !== undefined) {
           button2Node.if = node.attrs.button2If as ElementalActionNode["if"];
+        }
+        if (node.attrs?.button2OpenInNewTab) {
+          button2Node.open_in_new_tab = true;
         }
 
         return [button1Node, button2Node];

--- a/packages/react-designer/src/types/elemental.types.ts
+++ b/packages/react-designer/src/types/elemental.types.ts
@@ -198,6 +198,8 @@ export interface ElementalActionNode extends IsElementalNode {
    * Kept for backward compatibility when reading old templates.
    */
   color?: string;
+  /** When true, links will open in a new browser tab */
+  open_in_new_tab?: boolean;
   /**
    * @deprecated Legacy nested border format. Use flat `border_radius` and `border_size` instead.
    * Kept for backward compatibility when reading old templates.


### PR DESCRIPTION
## Summary
- Adds `open_in_new_tab` optional boolean property to `ElementalActionNode` type
- Adds `openInNewTab` attribute to tiptap Button extension and `button1OpenInNewTab`/`button2OpenInNewTab` to ButtonRow extension
- Wires the property through `convertElementalToTiptap` and `convertTiptapToElemental` for full round-trip support
- Adds "Open link in new tab" toggle switch in the inbox sidebar for both primary and secondary action buttons, rendered below each button's Action URL field
- All sync paths updated: editor → sidebar, sidebar → elemental, sidebar → tiptap attributes

## Test plan
- [ ] Enable a primary button in the inbox editor, toggle "Open link in new tab" on, verify it persists after save/reload
- [ ] Enable both buttons, toggle "Open link in new tab" independently for each, verify they save separately
- [ ] Verify toggling off removes `open_in_new_tab` from the elemental output
- [ ] Verify the toggle state syncs correctly when loading an existing template with `open_in_new_tab: true`


Made with [Cursor](https://cursor.com)