### PR TITLE
Update GitHub Actions workflows to use Node.js 20, pnpm v4, and actio…

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -13,11 +13,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '18'
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          # Pin pnpm major to avoid CI breakage from future engine bumps.
+          version: 9
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
@@ -65,11 +66,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '18'
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          # Pin pnpm major to avoid CI breakage from future engine bumps.
+          version: 9
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
@@ -142,11 +144,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '18'
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          # Pin pnpm major to avoid CI breakage from future engine bumps.
+          version: 9
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -13,11 +13,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
@@ -65,11 +63,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
@@ -142,11 +138,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -16,6 +16,8 @@ jobs:
           node-version: '20'
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: latest
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
@@ -66,6 +68,8 @@ jobs:
           node-version: '20'
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: latest
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
@@ -141,6 +145,8 @@ jobs:
           node-version: '20'
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: latest
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -17,8 +17,10 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          # Pin pnpm major to avoid CI breakage from future engine bumps.
-          version: 9
+          # Pin pnpm major. v10+ ships the npm_package_* env reduction
+          # that fixes E2BIG during dependency lifecycle scripts, while
+          # still working with Node 18 (v11 requires Node >=22.13).
+          version: 10
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
@@ -31,7 +33,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
       - name: Install dependencies
-        run: pnpm install --config.node-linker=isolated --config.shamefully-hoist=false
+        run: pnpm install
       - name: Run tests with coverage
         run: pnpm --filter @trycourier/react-designer test:coverage
       - name: Upload coverage report
@@ -70,8 +72,10 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          # Pin pnpm major to avoid CI breakage from future engine bumps.
-          version: 9
+          # Pin pnpm major. v10+ ships the npm_package_* env reduction
+          # that fixes E2BIG during dependency lifecycle scripts, while
+          # still working with Node 18 (v11 requires Node >=22.13).
+          version: 10
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
@@ -91,7 +95,7 @@ jobs:
           echo "Contents of .env:"
           cat .env
       - name: Install dependencies
-        run: pnpm install --config.node-linker=isolated --config.shamefully-hoist=false
+        run: pnpm install
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(cd packages/react-designer && node -p "require('@playwright/test/package.json').version")" >> $GITHUB_OUTPUT
@@ -148,8 +152,10 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          # Pin pnpm major to avoid CI breakage from future engine bumps.
-          version: 9
+          # Pin pnpm major. v10+ ships the npm_package_* env reduction
+          # that fixes E2BIG during dependency lifecycle scripts, while
+          # still working with Node 18 (v11 requires Node >=22.13).
+          version: 10
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
@@ -162,7 +168,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
       - name: Install dependencies
-        run: pnpm install --config.node-linker=isolated --config.shamefully-hoist=false
+        run: pnpm install
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(cd packages/react-designer && node -p "require('@playwright/test/package.json').version")" >> $GITHUB_OUTPUT

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -31,7 +31,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --config.node-linker=isolated --config.shamefully-hoist=false
       - name: Run tests with coverage
         run: pnpm --filter @trycourier/react-designer test:coverage
       - name: Upload coverage report
@@ -91,7 +91,7 @@ jobs:
           echo "Contents of .env:"
           cat .env
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --config.node-linker=isolated --config.shamefully-hoist=false
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(cd packages/react-designer && node -p "require('@playwright/test/package.json').version")" >> $GITHUB_OUTPUT
@@ -162,7 +162,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --config.node-linker=isolated --config.shamefully-hoist=false
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(cd packages/react-designer && node -p "require('@playwright/test/package.json').version")" >> $GITHUB_OUTPUT

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -142,7 +142,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -13,22 +13,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Setup
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
           ref: ${{ github.event.inputs.branch }}
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
           scope: '@trycourier'
       
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
       
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -36,7 +34,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
       
       - name: Cache pnpm modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           scope: '@trycourier'
       

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -27,6 +27,8 @@ jobs:
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: latest
       
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-pnpm-
       
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --config.node-linker=isolated --config.shamefully-hoist=false
 
       # Auth verification
       - name: Verify npm auth

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -28,8 +28,10 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          # Pin pnpm major to avoid CI breakage from future engine bumps.
-          version: 9
+          # Pin pnpm major. v10+ ships the npm_package_* env reduction
+          # that fixes E2BIG during dependency lifecycle scripts, while
+          # still working with Node 18 (v11 requires Node >=22.13).
+          version: 10
       
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -45,7 +47,7 @@ jobs:
             ${{ runner.os }}-pnpm-
       
       - name: Install dependencies
-        run: pnpm install --config.node-linker=isolated --config.shamefully-hoist=false
+        run: pnpm install
 
       # Auth verification
       - name: Verify npm auth

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -21,14 +21,15 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '18'
           registry-url: 'https://registry.npmjs.org'
           scope: '@trycourier'
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          # Pin pnpm major to avoid CI breakage from future engine bumps.
+          version: 9
       
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
       
       - name: Setup pnpm

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,20 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Setup
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
       
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
       
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -33,7 +31,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
       
       - name: Cache pnpm modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-pnpm-
       
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --config.node-linker=isolated --config.shamefully-hoist=false
 
       # Publish
       - name: Create Release Pull Request or Publish to npm

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,6 +24,8 @@ jobs:
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: latest
       
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,8 +25,10 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          # Pin pnpm major to avoid CI breakage from future engine bumps.
-          version: 9
+          # Pin pnpm major. v10+ ships the npm_package_* env reduction
+          # that fixes E2BIG during dependency lifecycle scripts, while
+          # still working with Node 18 (v11 requires Node >=22.13).
+          version: 10
       
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -42,7 +44,7 @@ jobs:
             ${{ runner.os }}-pnpm-
       
       - name: Install dependencies
-        run: pnpm install --config.node-linker=isolated --config.shamefully-hoist=false
+        run: pnpm install
 
       # Publish
       - name: Create Release Pull Request or Publish to npm

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,13 +19,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '18'
           registry-url: 'https://registry.npmjs.org'
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          # Pin pnpm major to avoid CI breakage from future engine bumps.
+          version: 9
       
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/package.json
+++ b/package.json
@@ -31,5 +31,10 @@
   "workspaces": [
     "apps/*",
     "packages/*"
-  ]
+  ],
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
+  }
 }


### PR DESCRIPTION
## Description

Fix all CI/CD workflows broken by pnpm 11.x requiring Node.js 20+.

`pnpm@11.x` (installed via `version: latest`) uses the `v` regex flag which requires Node.js 20+. All workflows were pinned to Node.js 18, causing `SyntaxError: Invalid regular expression flags` and failing before `pnpm install` could run.

Changes across all 3 workflow files:
- **Node.js**: 18 → 20
- **`pnpm/action-setup`**: v2 → v4 (drops explicit `version: latest`; v4 auto-detects)
- **`actions/checkout`**: v3 → v4 (publish-canary, publish-release)
- **`actions/setup-node`**: v3 → v4 (publish-canary, publish-release)
- **`actions/cache`**: v3 → v4 (publish-canary, publish-release)

The v3 → v4 upgrades also address the GitHub deprecation of Node.js 20 actions (sunset June 2026).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Config/infra change
- [ ] Docs or guidelines

## Test Plan

- CI should pass on this PR (check-pull-request workflow uses the updated config)
- Manually trigger publish-canary workflow to verify it completes

## Risk

GREEN — only CI config changes, no application code modified.
