### PR TITLE
fix: BrandFooter placeholder for empty content and fix broken/flaky e2e tests

### DIFF
--- a/.changeset/salty-snails-remain.md
+++ b/.changeset/salty-snails-remain.md
@@ -1,0 +1,5 @@
+---
+"@trycourier/react-designer": patch
+---
+
+Fix BrandFooter placeholder for empty content and fix flaky/broken e2e tests (alignment helper, read-only editor selector, variable chip timing)

--- a/packages/react-designer/e2e/full-cycle/ui-helpers.ts
+++ b/packages/react-designer/e2e/full-cycle/ui-helpers.ts
@@ -77,11 +77,9 @@ export async function setTextColor(page: Page, color: string): Promise<void> {
 // ═══════════════════════════════════════════════════════════════════════
 
 /**
- * Set text alignment by clicking the alignment button in the bubble toolbar.
+ * Set text alignment via TipTap command.
  *
- * IMPORTANT: The cursor must be inside a paragraph that already has text,
- * because the bubble menu only appears after clicking on a text node which
- * triggers the Selection extension's `isSelected` state.
+ * The cursor must be inside a paragraph/heading that already has text.
  *
  * Typical usage:
  *   await typeText(page, "...");
@@ -91,28 +89,12 @@ export async function setAlignment(
   page: Page,
   alignment: "left" | "center" | "right" | "justify"
 ): Promise<void> {
-  // 1. Click on the current paragraph text to trigger isSelected → bubble menu
-  //    We click the .node-element that contains the cursor.
-  const nodeElement = page
-    .locator(
-      ".node-element .is-empty, .node-element p, .node-element h1, .node-element h2, .node-element h3"
-    )
-    .last();
-  await nodeElement.click();
-  await page.waitForTimeout(300);
-
-  // 2. Find the alignment button by its lucide SVG icon class
-  const svgClass: Record<string, string> = {
-    left: "lucide-align-left",
-    center: "lucide-align-center",
-    right: "lucide-align-right",
-    justify: "lucide-align-justify",
-  };
-
-  const button = page.locator(`button:has(svg.${svgClass[alignment]})`);
-  await button.waitFor({ state: "visible", timeout: 3000 });
-  await button.click();
-  await page.waitForTimeout(150);
+  await page.evaluate((a) => {
+    const ed = (window as any).__COURIER_CREATE_TEST__?.currentEditor;
+    if (!ed) throw new Error("Editor not available");
+    ed.chain().focus().setTextAlign(a).run();
+  }, alignment);
+  await page.waitForTimeout(100);
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/packages/react-designer/e2e/multiple-template-providers.spec.ts
+++ b/packages/react-designer/e2e/multiple-template-providers.spec.ts
@@ -82,25 +82,23 @@ test.describe("Multiple TemplateProvider Instances", () => {
     await page.goto("/test-app", { waitUntil: "domcontentloaded" });
     await page.waitForTimeout(2000);
 
-    // Find all editors on the page
-    const editors = page.locator(".tiptap.ProseMirror");
+    // Find editable editors (excludes read-only editors like BrandFooter)
+    const editors = page.locator('.tiptap.ProseMirror[contenteditable="true"]');
     const editorCount = await editors.count();
-    console.log(`📊 Found ${editorCount} editor instance(s)`);
+    console.log(`📊 Found ${editorCount} editable editor instance(s)`);
 
     // If we have only one editor, this test passes as the basic case
     if (editorCount === 1) {
       const editor = editors.first();
       await expect(editor).toBeVisible();
-      await expect(editor).toHaveAttribute("contenteditable", "true");
       console.log("✅ Single editor instance works correctly");
       return;
     }
 
     // If we have multiple editors, verify they're independent
     if (editorCount >= 2) {
-      console.log(`✅ Multiple editor instances detected: ${editorCount}`);
+      console.log(`✅ Multiple editable editor instances detected: ${editorCount}`);
 
-      // Verify all visible editors are editable
       let visibleCount = 0;
       for (let i = 0; i < editorCount; i++) {
         const editor = editors.nth(i);
@@ -108,7 +106,6 @@ test.describe("Multiple TemplateProvider Instances", () => {
         if (isVisible) {
           console.log(`🔍 Checking editor ${i + 1}/${editorCount}`);
           await expect(editor).toBeVisible();
-          await expect(editor).toHaveAttribute("contenteditable", "true");
           visibleCount++;
         } else {
           console.log(`⚠️ Editor ${i + 1} not visible, skipping`);
@@ -160,19 +157,17 @@ test.describe("Multiple TemplateProvider Instances", () => {
     await page.goto("/test-app", { waitUntil: "domcontentloaded" });
     await page.waitForTimeout(2000);
 
-    // Verify at least one editor is present and functional
-    const editors = page.locator(".tiptap.ProseMirror");
+    // Find editable editors (excludes read-only editors like BrandFooter)
+    const editors = page.locator('.tiptap.ProseMirror[contenteditable="true"]');
     const editorCount = await editors.count();
 
     expect(editorCount).toBeGreaterThanOrEqual(1);
 
-    // Verify each editor is functional
     for (let i = 0; i < Math.min(editorCount, 3); i++) {
       const editor = editors.nth(i);
       const isVisible = await editor.isVisible().catch(() => false);
       if (isVisible) {
         await expect(editor).toBeVisible();
-        await expect(editor).toHaveAttribute("contenteditable", "true");
         console.log(`✅ Editor ${i + 1} is functional`);
       } else {
         console.log(`⚠️ Editor ${i + 1} not visible, skipping`);
@@ -188,11 +183,11 @@ test.describe("Multiple TemplateProvider Instances", () => {
     await page.goto("/test-app", { waitUntil: "domcontentloaded" });
     await page.waitForTimeout(2000);
 
-    const editors = page.locator(".tiptap.ProseMirror");
+    const editors = page.locator('.tiptap.ProseMirror[contenteditable="true"]');
     const editorCount = await editors.count();
 
     if (editorCount < 2) {
-      console.log("⚠️ Test requires at least 2 editors, skipping");
+      console.log("⚠️ Test requires at least 2 editable editors, skipping");
       test.skip();
       return;
     }
@@ -205,11 +200,9 @@ test.describe("Multiple TemplateProvider Instances", () => {
     const secondVisible = await secondEditor.isVisible().catch(() => false);
     if (!secondVisible) {
       console.log("⚠️ Second editor not visible, testing with first editor only");
-      // At least verify first editor works
       await firstEditor.click();
       await page.keyboard.type("TEST");
       await expect(firstEditor).toBeVisible();
-      await expect(firstEditor).toHaveAttribute("contenteditable", "true");
       console.log("✅ First editor functional (architecture supports isolation)");
       return;
     }

--- a/packages/react-designer/e2e/variable-input-subject.spec.ts
+++ b/packages/react-designer/e2e/variable-input-subject.spec.ts
@@ -223,7 +223,8 @@ test.describe("VariableInput Subject Field", () => {
     await page.keyboard.type("Order #", { delay: 50 });
     await page.waitForTimeout(200);
     await page.keyboard.type("{{orderNumber}}", { delay: 50 });
-    await page.waitForTimeout(500);
+    // Wait for the input rule to convert the typed text into a variable chip
+    await expect(subjectContainer.locator(".courier-variable-chip")).toBeVisible({ timeout: 5000 });
     await page.keyboard.type(" confirmed", { delay: 50 });
     await page.waitForTimeout(300);
 

--- a/packages/react-designer/src/components/BrandEditor/Editor/BrandFooter/BrandFooter.tsx
+++ b/packages/react-designer/src/components/BrandEditor/Editor/BrandFooter/BrandFooter.tsx
@@ -1,4 +1,5 @@
 import { ExtensionKit } from "@/components/extensions/extension-kit";
+import { Placeholder } from "@tiptap/extension-placeholder";
 import { isTemplateLoadingAtom } from "@/components/Providers/store";
 import { brandEditorAtom, type VariableViewMode } from "@/components/TemplateEditor/store";
 import {
@@ -110,6 +111,14 @@ const BrandFooterComponent = ({
       [
         ...ExtensionKit({
           setSelectedNode,
+        }).filter((ext) => ext?.name !== "placeholder"),
+        Placeholder.configure({
+          includeChildren: true,
+          showOnlyCurrent: false,
+          placeholder: "",
+          emptyEditorClass: "is-editor-empty",
+          emptyNodeClass: "is-empty",
+          showOnlyWhenEditable: true,
         }),
         EscapeHandlerExtension,
       ].filter((e): e is AnyExtension => e !== undefined),
@@ -119,7 +128,13 @@ const BrandFooterComponent = ({
   return (
     <div className="courier-flex courier-flex-row courier-gap-6 courier-justify-between courier-items-start">
       <EditorProvider
-        content={convertMarkdownToTiptap(value ?? "")}
+        content={(() => {
+          const doc = convertMarkdownToTiptap(value ?? "");
+          if (doc.content.length === 0) {
+            doc.content = [{ type: "paragraph", attrs: { textAlign: "left" } }];
+          }
+          return doc;
+        })()}
         extensions={extensions}
         editable={!readOnly}
         autofocus={!readOnly}

--- a/packages/react-designer/src/styles.css
+++ b/packages/react-designer/src/styles.css
@@ -124,6 +124,14 @@
             @apply courier-p-0;
           }
         }
+
+        .is-empty {
+          p {
+            &::after {
+              content: "Write footer text...";
+            }
+          }
+        }
       }
 
       [data-cypress="draggable-handle"] {


### PR DESCRIPTION
## Description

- Add custom Placeholder extension to BrandFooter so empty footers show placeholder text and always contain at least one paragraph node
- Fix multiple-template-providers e2e tests that incorrectly asserted all TipTap editors on the page are editable (BrandFooter is intentionally read-only)
- Fix flaky variable-input-subject e2e test by waiting for the variable chip element to appear instead of using a fixed 500ms timeout
- Fix heading/paragraph visual parity e2e tests by using programmatic TipTap `setTextAlign` command instead of fragile bubble menu button clicks

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Plan

- Ran `multiple-template-providers.spec.ts` — 3/3 pass (previously 2 failed)
- Ran `variable-input-subject.spec.ts` caret placement test 3x with `--repeat-each=3` — 3/3 pass (previously flaky)
- Heading/paragraph visual parity tests use the same `setAlignment` fix; requires full-cycle API credentials to run locally (validated via CI)

## Risk

GREEN

## Related issues

Closes C-18307

## Additional checklist

- [x] Changes have been manually tested
- [x] Changeset added (if needed for publishing)

Made with [Cursor](https://cursor.com)