### PR TITLE
fix(ci): restore npm OIDC publish in publish-npm workflow

### DIFF
--- a/.cursor/skills/publish-canary/SKILL.md
+++ b/.cursor/skills/publish-canary/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 
 # Publish Canary
 
-Triggers the `publish-npm.yml` GitHub Actions workflow (canary job) on the `trycourier/courier-designer` repo using the current git branch. Publishing uses npm Trusted Publishing (OIDC) — no `NPM_TOKEN` secret required.
+Triggers the `publish-npm.yml` GitHub Actions workflow (canary job) on the `trycourier/courier-designer` repo using the current git branch. Publishing uses npm Trusted Publishing (OIDC) on Node 24 — no `NPM_TOKEN` secret required. Do not use `npm whoami` to verify OIDC; auth is validated at publish time.
 
 ## Steps
 
@@ -50,4 +50,4 @@ gh run list --repo trycourier/courier-designer --workflow=publish-npm.yml --limi
 - `--field branch` is the branch to **check out and publish**; `--ref` is the branch that **provides the workflow file**.
 - On feature branches, both are usually the same branch name.
 - The workflow publishes `@trycourier/react-designer` to npm under the `canary` tag (e.g. `0.7.0-canary.0`).
-- npm Trusted Publisher must be configured for `trycourier/courier-designer` → `publish-npm.yml`.
+- npm Trusted Publisher must be configured for `trycourier/courier-designer` → `publish-npm.yml` (Node >=22.14, npm >=11.5.1).

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          # npm Trusted Publishing requires Node >=22.14 and npm >=11.5.1
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           scope: '@trycourier'
 
@@ -37,8 +38,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           # Pin pnpm major. v10+ ships the npm_package_* env reduction
-          # that fixes E2BIG during dependency lifecycle scripts, while
-          # still working with Node 18 (v11 requires Node >=22.13).
+          # that fixes E2BIG during dependency lifecycle scripts.
           version: 10
 
       - name: Get pnpm store directory
@@ -57,8 +57,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Verify npm OIDC auth
-        run: npm whoami
+      - name: Prepare .npmrc for OIDC publish
+        run: |
+          NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          sed -i '/_authToken/d' "$NPMRC"
+          echo "NODE_AUTH_TOKEN=" >> "$GITHUB_ENV"
 
       - name: Create and publish canary release
         run: pnpm release:canary
@@ -81,7 +84,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          # npm Trusted Publishing requires Node >=22.14 and npm >=11.5.1
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           scope: '@trycourier'
 
@@ -89,8 +93,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           # Pin pnpm major. v10+ ships the npm_package_* env reduction
-          # that fixes E2BIG during dependency lifecycle scripts, while
-          # still working with Node 18 (v11 requires Node >=22.13).
+          # that fixes E2BIG during dependency lifecycle scripts.
           version: 10
 
       - name: Get pnpm store directory
@@ -109,8 +112,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Verify npm OIDC auth
-        run: npm whoami
+      - name: Prepare .npmrc for OIDC publish
+        run: |
+          NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          sed -i '/_authToken/d' "$NPMRC"
+          echo "NODE_AUTH_TOKEN=" >> "$GITHUB_ENV"
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
## Description

Fixes `publish-release` and `publish-canary` failing with `npm error 401` on `npm whoami` after the OIDC migration.

- Remove `npm whoami` verification (OIDC auth only applies at publish time; see [npm trusted publishers docs](https://docs.npmjs.com/trusted-publishers))
- Bump publish jobs to Node 24 (Trusted Publishing requires Node ≥22.14 and npm ≥11.5.1)
- Add a pre-publish step to strip `setup-node`'s empty `_authToken` from `.npmrc` and clear `NODE_AUTH_TOKEN` so npm uses OIDC instead of classic token auth
- Update publish-canary skill notes

**Manual step after merge:** confirm npm Trusted Publisher on `@trycourier/react-designer` points to `trycourier/courier-designer` + `publish-npm.yml`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Config/infra change
- [ ] Docs or guidelines

## Test Plan

- [ ] Merge and verify `publish-release` on `main` completes without auth errors
- [ ] Run `publish-npm.yml` via `workflow_dispatch` (canary) and confirm a `canary`-tagged package publishes
- [ ] Confirm npm Trusted Publisher settings on `@trycourier/react-designer`

## Risk

GREEN — CI workflow only; no runtime package changes.

## Related issues

Closes [C-18595](https://linear.app/trycourier/issue/C-18595)

## Additional checklist

- [ ] Changes have been manually tested
- [ ] Changeset added (if needed for publishing)

Made with [Cursor](https://cursor.com)