### PR TITLE
fix: remove Codex review model override

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -26,8 +26,6 @@ jobs:
     with:
       runs_on_json: '["ubuntu-latest"]'
       install_codex_cli: true
-      codex_version: "0.120.0"
-      review_model: "gpt-5.3-codex"
       review_reasoning_effort: high
       max_inline_comments: "10"
     secrets:


### PR DESCRIPTION
## Summary
- remove stale Codex PR review overrides for `review_model` and `codex_version`
- allow the shared `trycourier/github-workflows@v1` defaults to apply (`gpt-5.5` and latest Codex CLI)

## Validation
- `git diff --check`
- assertion that the shared workflow ref remains `trycourier/github-workflows/.github/workflows/codex-pr-review.yml@v1`
- assertion that `review_model:` is no longer present
- assertion that `codex_version:` is no longer present