### PR TITLE
fix(ci): unblock Version Packages PR creation and silence noisy workflows

### DIFF
--- a/.github/workflows/auto-approve-docs.yml
+++ b/.github/workflows/auto-approve-docs.yml
@@ -1,8 +1,11 @@
 name: Auto-approve doc-only PRs
 
+# Temporarily disabled — uncomment `on` below and remove workflow_dispatch to re-enable.
+# on:
+#   pull_request:
+#     types: [opened, synchronize, reopened, ready_for_review]
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -1,14 +1,17 @@
 name: codex-pr-review
 
+# Temporarily disabled — uncomment `on` below and remove workflow_dispatch to re-enable.
+# on:
+#   pull_request:
+#     types:
+#       - opened
+#       - synchronize
+#       - reopened
+#       - ready_for_review
+#     branches:
+#       - main
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-    branches:
-      - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/codex-review-override.yml
+++ b/.github/workflows/codex-review-override.yml
@@ -1,10 +1,13 @@
 name: codex-review-override
 
+# Temporarily disabled — uncomment `on` below and remove workflow_dispatch to re-enable.
+# on:
+#   issue_comment:
+#     types:
+#       - created
+#       - edited
 on:
-  issue_comment:
-    types:
-      - created
-      - edited
+  workflow_dispatch:
 
 permissions:
   actions: write

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -73,6 +73,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -204,5 +205,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: prNumber,
-              body: pr.body + checklist
+              body: (pr.body ?? '') + checklist
             });

--- a/.github/workflows/risk-tier-policy.yml
+++ b/.github/workflows/risk-tier-policy.yml
@@ -1,8 +1,11 @@
 name: Risk Tier Policy
 
+# Temporarily disabled — uncomment `on` below and remove workflow_dispatch to re-enable.
+# on:
+#   pull_request:
+#     types: [opened, synchronize, reopened, ready_for_review, edited, auto_merge_enabled, auto_merge_disabled]
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, edited, auto_merge_enabled, auto_merge_disabled]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description

Fixes two courier-designer GitHub Actions issues from C-18768:

1. **Release CI** — `publish-release` could version and push `changeset-release/main` but failed to open the Version Packages PR with `Resource not accessible by integration` because `GITHUB_TOKEN` lacked `pull-requests: write`. Adds that permission and guards the checklist step against a null PR body.
2. **Noisy workflows** — Temporarily disables auto-triggered org automation workflows (`auto-approve-docs`, `risk-tier-policy`, `codex-pr-review`, `codex-review-override`) that emailed "No jobs were run" on most PRs. Original triggers are preserved as comments for easy re-enable.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Config/infra change
- [ ] Docs or guidelines

## Test Plan

- [ ] Merge and confirm `Publish npm` on `main` can create/update a Version Packages PR (or re-run workflow after merge)
- [ ] Confirm disabled workflows no longer trigger on PR synchronize events
- [ ] Optionally open PR manually from existing `changeset-release/main` to unblock 0.8.1 release

## Risk

ORANGE — touches `.github/workflows/` and release automation; risk-tier labels and Codex review are paused until workflows are re-enabled.

## Related issues

Closes C-18768

## Additional checklist

- [ ] Changes have been manually tested
- [x] Changeset added (if needed for publishing) — not needed (workflow-only change)

Made with [Cursor](https://cursor.com)