### PR TITLE
fix(dnd): stabilize column drag-and-drop drop targets

### DIFF
--- a/.changeset/brave-columns-settle.md
+++ b/.changeset/brave-columns-settle.md
@@ -1,0 +1,5 @@
+---
+"@trycourier/react-designer": minor
+---
+
+Make column drag-and-drop deterministic so a block dropped over a cell always lands in the highlighted cell instead of before the column, and allow dropping blocks into the gap between two stacked columns.

--- a/.cursor/skills/changeset/SKILL.md
+++ b/.cursor/skills/changeset/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: changeset
+description: >-
+  Analyze branch changes and create a Changesets release note in .changeset/.
+  Use when the user asks to create/add a changeset, bump a package version, or
+  prepare a release note for the courier-designer monorepo.
+---
+
+# Changeset
+
+Create a [Changesets](https://github.com/changesets/changesets) release note for
+the current branch's changes, then write it to `.changeset/`.
+
+## Workflow
+
+1. **Inspect the changes** against the base branch (`main`):
+
+```bash
+git diff --stat main...HEAD
+git diff main...HEAD
+```
+
+2. **Determine affected packages.** Only published packages get a changeset.
+   - `@trycourier/react-designer` — the only publishable package.
+   - Ignored / private (never include): `editor-dev`, `nextjs-demo`, `@trycourier/vue-designer`.
+   - If the changes touch **only** ignored packages, root config, CI, or repo
+     docs (and not the published library), tell the user no changeset is needed
+     instead of creating an empty one.
+
+3. **Choose the bump level:**
+   - `major` — breaking changes, removed features, changed/renamed public APIs or props.
+   - `minor` — new features or enhancements (backwards compatible).
+   - `patch` — bug fixes, refactors, small improvements, docs.
+   - When genuinely uncertain between minor and patch, prefer `minor`.
+
+4. **Write a brief description** (1–2 sentences) covering *what* changed and
+   *why*, in the imperative/present tense. This becomes the changelog entry.
+
+5. **Create the file** at `.changeset/<unique-slug>.md`. Use a short random
+   three-word kebab slug (e.g. `swift-lions-jump.md`) and confirm the name is not
+   already taken in `.changeset/` before writing.
+
+6. **Show the created file path and its content** to the user.
+
+## File format
+
+```markdown
+---
+"@trycourier/react-designer": minor
+---
+
+Brief description of what changed and why.
+```
+
+- The frontmatter key is the exact package name; the value is the bump level.
+- List multiple packages on separate lines only if more than one publishable
+  package actually changed (rare in this repo).
+
+## Example
+
+Branch adds a `colorScheme` prop to `TemplateEditor`:
+
+`.changeset/quiet-pandas-sing.md`
+
+```markdown
+---
+"@trycourier/react-designer": minor
+---
+
+Add dark mode support via a `colorScheme` prop on `TemplateEditor` and related components.
+```
+
+## Notes
+
+- This repo uses `pnpm`. Avoid the interactive `pnpm changeset` prompt — write
+  the file directly so the result is deterministic.
+- Base branch is `main` (`.changeset/config.json`).

--- a/packages/react-designer/e2e/column-drag-and-drop.spec.ts
+++ b/packages/react-designer/e2e/column-drag-and-drop.spec.ts
@@ -582,4 +582,176 @@ test.describe("Column Drag and Drop", () => {
       }
     }
   });
+
+  test("should drop into the cell when targeting the cell's top area", async ({ page }) => {
+    const editor = getMainEditor(page);
+
+    await editor.click({ force: true });
+    await page.waitForTimeout(200);
+
+    // Add a uniquely-identifiable paragraph (drag source), then a column.
+    await page.evaluate(() => {
+      const ed = (window as any).__COURIER_CREATE_TEST__?.currentEditor;
+      if (ed) {
+        ed.commands.insertContent("<p>DRAG_TOP_CELL</p>");
+        ed.commands.setColumn({ columnsCount: 2 });
+      }
+    });
+
+    await page.waitForTimeout(500);
+
+    // Close any tooltips that might intercept pointer events.
+    await page.evaluate(() => {
+      document.querySelectorAll("[data-tippy-root]").forEach((root) => {
+        const instance = (root as any)._tippy;
+        if (instance) instance.hide();
+      });
+    });
+    await page.waitForTimeout(200);
+
+    const dragSource = page.locator('.draggable-item:has-text("DRAG_TOP_CELL")').first();
+    expect(await dragSource.count()).toBeGreaterThan(0);
+
+    const columnCell = page.locator('[data-column-cell="true"]').first();
+    expect(await columnCell.count()).toBeGreaterThan(0);
+
+    const sourceBox = await dragSource.boundingBox();
+    const cellBox = await columnCell.boundingBox();
+    expect(sourceBox).toBeTruthy();
+    expect(cellBox).toBeTruthy();
+
+    if (sourceBox && cellBox) {
+      // Begin the drag from the source block (near its drag handle).
+      await page.mouse.move(sourceBox.x + 10, sourceBox.y + sourceBox.height / 2, { steps: 5 });
+      await page.mouse.down();
+      await page.waitForTimeout(200);
+
+      // Aim near the very TOP of the cell (the previously-buggy hotspot that
+      // dropped before the column instead of into the cell).
+      await page.mouse.move(cellBox.x + cellBox.width / 2, cellBox.y + 8, { steps: 10 });
+      await page.waitForTimeout(300);
+
+      await page.mouse.up();
+      await page.waitForTimeout(1000);
+
+      // The block must land INSIDE a cell, not before the column.
+      const inCell = await page.evaluate(() => {
+        const cells = document.querySelectorAll('[data-column-cell="true"]');
+        return Array.from(cells).some((cell) => cell.textContent?.includes("DRAG_TOP_CELL"));
+      });
+
+      expect(inCell).toBe(true);
+    }
+  });
+
+  test("should drop a block in the gap between two stacked columns", async ({ page }) => {
+    const editor = getMainEditor(page);
+
+    await editor.click({ force: true });
+    await page.waitForTimeout(200);
+
+    // Build a leading paragraph (drag source) followed by two ADJACENT top-level
+    // columns with distinct ids. Calling setColumn twice in a row can collide on
+    // its Date.now()-based id and nest the second column, so we set explicit JSON.
+    await page.evaluate(() => {
+      const ed = (window as any).__COURIER_CREATE_TEST__?.currentEditor;
+      if (!ed) return;
+
+      const makeColumn = (suffix: string) => {
+        const columnId = `node-test-${suffix}`;
+        return {
+          type: "column",
+          attrs: { columnsCount: 2, id: columnId },
+          content: [
+            {
+              type: "columnRow",
+              content: [0, 1].map((index) => ({
+                type: "columnCell",
+                attrs: { id: `cell-${suffix}-${index}`, index, columnId, width: 50 },
+                content: [{ type: "paragraph" }],
+              })),
+            },
+          ],
+        };
+      };
+
+      ed.commands.setContent({
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [{ type: "text", text: "DRAG_BETWEEN" }] },
+          makeColumn("a"),
+          makeColumn("b"),
+        ],
+      });
+    });
+
+    await page.waitForTimeout(500);
+
+    // Close any tooltips that might intercept pointer events.
+    await page.evaluate(() => {
+      document.querySelectorAll("[data-tippy-root]").forEach((root) => {
+        const instance = (root as any)._tippy;
+        if (instance) instance.hide();
+      });
+    });
+    await page.waitForTimeout(200);
+
+    const columns = page.locator('[data-node-type="column"]');
+    expect(await columns.count()).toBeGreaterThanOrEqual(2);
+
+    const dragSource = page.locator('.draggable-item:has-text("DRAG_BETWEEN")').first();
+    expect(await dragSource.count()).toBeGreaterThan(0);
+
+    const sourceBox = await dragSource.boundingBox();
+    const firstColBox = await columns.nth(0).boundingBox();
+    const secondColBox = await columns.nth(1).boundingBox();
+    expect(sourceBox).toBeTruthy();
+    expect(firstColBox).toBeTruthy();
+    expect(secondColBox).toBeTruthy();
+
+    if (sourceBox && firstColBox && secondColBox) {
+      await page.mouse.move(sourceBox.x + 10, sourceBox.y + sourceBox.height / 2, { steps: 5 });
+      await page.mouse.down();
+      await page.waitForTimeout(200);
+
+      // Move over the lower column first so the drag is active, then re-measure
+      // the live geometry (the layout can shift once the drag starts) and aim
+      // precisely at the contiguous gap strip between the two columns.
+      await page.mouse.move(secondColBox.x + secondColBox.width / 2, secondColBox.y + 30, {
+        steps: 10,
+      });
+      await page.waitForTimeout(200);
+
+      const target = await page.evaluate(() => {
+        const cols = document.querySelectorAll('[data-node-type="column"]');
+        const colB = cols[1] as HTMLElement;
+        const rb = colB.getBoundingClientRect();
+        return { x: rb.left + rb.width / 2, y: rb.top + 1 };
+      });
+
+      await page.mouse.move(target.x, target.y, { steps: 10 });
+      await page.waitForTimeout(300);
+
+      await page.mouse.up();
+      await page.waitForTimeout(1000);
+
+      // A non-column block must now sit between the two columns at top level.
+      const insertedBetween = await page.evaluate(() => {
+        const ed = (window as any).__COURIER_CREATE_TEST__?.currentEditor;
+        if (!ed) return false;
+        const types: string[] = [];
+        ed.state.doc.forEach((node: any) => types.push(node.type.name));
+        return types.some(
+          (type, index) =>
+            index > 0 &&
+            index < types.length - 1 &&
+            type !== "column" &&
+            types[index - 1] === "column" &&
+            types[index + 1] === "column"
+        );
+      });
+
+      expect(insertedBetween).toBe(true);
+    }
+  });
 });

--- a/packages/react-designer/src/components/TemplateEditor/hooks/usePragmaticDnd.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/hooks/usePragmaticDnd.test.tsx
@@ -233,15 +233,22 @@ describe("usePragmaticDnd", () => {
       expect(result.current.cleanupPlaceholder).toBeDefined();
     });
 
-    it("should route column-cell foremost drop to parent column edge target", () => {
+    it("should drop INTO the cell when a column cell is the foremost target", () => {
       vi.useFakeTimers();
 
       const setItems = vi.fn();
       const mockInsertContentAt = vi.fn();
-      const mockSetTextSelection = vi.fn();
-      const mockViewFocus = vi.fn();
+      const mockDispatch = vi.fn();
 
-      const edgeRerouteEditor = {
+      // A column that the cell drop will be inserted into. handleColumnDrop
+      // locates it by id via descendants and rebuilds its structure.
+      const columnNode = {
+        type: { name: "column" },
+        attrs: { id: "column-parent", columnsCount: 2 },
+        nodeSize: 10,
+      };
+
+      const cellDropEditor = {
         ...mockEditor,
         state: {
           ...mockEditor.state!,
@@ -249,24 +256,11 @@ describe("usePragmaticDnd", () => {
             ...mockEditor.state!.doc,
             childCount: 1,
             content: { size: 10 },
-            child: vi.fn(() => ({ nodeSize: 10 })),
-            // pos=0: parent column target, pos=10: inserted paragraph
-            nodeAt: vi.fn((pos: number) => {
-              if (pos === 0) {
-                return {
-                  type: { name: "column" },
-                  attrs: { id: "column-parent" },
-                  nodeSize: 10,
-                } as any;
-              }
-              if (pos === 10) {
-                return {
-                  type: { name: "paragraph" },
-                  attrs: { id: "inserted-paragraph" },
-                } as any;
-              }
-              return null;
+            descendants: vi.fn((callback) => {
+              callback(columnNode as any, 0, null);
+              return true;
             }),
+            nodeAt: vi.fn(() => null),
             resolve: vi.fn(() => ({
               depth: 0,
               index: () => 0,
@@ -274,15 +268,26 @@ describe("usePragmaticDnd", () => {
               before: () => 0,
             })),
           },
+          tr: {
+            delete: vi.fn(),
+            insert: vi.fn(),
+            replaceWith: vi.fn(),
+          } as any,
         },
         commands: {
           ...mockEditor.commands!,
           insertContentAt: mockInsertContentAt,
-          setTextSelection: mockSetTextSelection,
         },
         view: {
           ...mockEditor.view!,
-          focus: mockViewFocus,
+          dispatch: mockDispatch,
+        },
+        schema: {
+          nodes: {
+            columnCell: { create: vi.fn(() => ({})) },
+            columnRow: { create: vi.fn(() => ({})) },
+          },
+          nodeFromJSON: vi.fn(() => ({})),
         },
         isDestroyed: false,
       };
@@ -292,7 +297,7 @@ describe("usePragmaticDnd", () => {
           usePragmaticDnd({
             items: { Sidebar: ["text"], Editor: [] },
             setItems,
-            editor: edgeRerouteEditor as unknown as Editor,
+            editor: cellDropEditor as unknown as Editor,
           }),
         {
           wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
@@ -313,12 +318,15 @@ describe("usePragmaticDnd", () => {
           },
           location: {
             current: {
+              // Cell is foremost, column wrapper is behind it. Even though the
+              // column wrapper is present, the cell must own the drop.
               dropTargets: [
                 {
                   data: {
                     type: "column-cell",
                     columnId: "column-parent",
                     index: 0,
+                    isEmpty: true,
                   },
                 },
                 {
@@ -337,13 +345,10 @@ describe("usePragmaticDnd", () => {
         });
       });
 
-      // Should use parent column edge target (pos=0, edge=bottom -> insertPos=10)
-      // rather than treating this as a column-cell drop.
-      expect(mockInsertContentAt).toHaveBeenCalledWith(
-        10,
-        expect.objectContaining({ type: "paragraph" })
-      );
-      expect(edgeRerouteEditor.view.dispatch).not.toHaveBeenCalled();
+      // The drop is handled as a column-cell drop (rebuilds cell content and
+      // dispatches a transaction) rather than being rerouted to the column edge.
+      expect(mockDispatch).toHaveBeenCalled();
+      expect(mockInsertContentAt).not.toHaveBeenCalled();
 
       act(() => {
         vi.runOnlyPendingTimers();

--- a/packages/react-designer/src/components/TemplateEditor/hooks/usePragmaticDnd.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/hooks/usePragmaticDnd.tsx
@@ -748,7 +748,7 @@ export const usePragmaticDnd = ({ items, setItems, editor }: UsePragmaticDndProp
       onDrop: ({ source, location }) => {
         const sourceData = source.data as unknown as DragData;
         const dropTargets = location.current.dropTargets;
-        let dropTarget = dropTargets[0];
+        const dropTarget = dropTargets[0];
 
         if (!dropTarget) {
           cleanupPlaceholder();
@@ -758,28 +758,13 @@ export const usePragmaticDnd = ({ items, setItems, editor }: UsePragmaticDndProp
           return;
         }
 
-        let rawTargetData = dropTarget.data as unknown as DropData | ColumnDropData;
+        const rawTargetData = dropTarget.data as unknown as DropData | ColumnDropData;
 
-        // If the foremost target is a column-cell but a parent column wrapper has
-        // an edge attached, the user is hovering in the column's edge zone and
-        // the drop should be routed to the column instead of into the cell.
-        // (See SortableItemWrapper's nested-target-foremost handling.)
-        if (rawTargetData.type === "column-cell" && dropTargets.length > 1) {
-          for (let i = 1; i < dropTargets.length; i++) {
-            const candidate = dropTargets[i];
-            const candidateData = candidate.data as { nodeType?: string };
-            if (
-              candidateData.nodeType === "column" &&
-              extractClosestEdge(candidate.data) !== null
-            ) {
-              dropTarget = candidate;
-              rawTargetData = candidate.data as unknown as DropData;
-              break;
-            }
-          }
-        }
-
-        // Handle column cell drop
+        // Handle column cell drop. The foremost target is a cell only when the
+        // cursor is geometrically over that cell (the column wrapper attaches an
+        // edge — and becomes foremost — only in its padding strips, outside the
+        // cells). So when a cell is foremost we always drop into it, keeping the
+        // drop consistent with the cell's highlight.
         if (rawTargetData.type === "column-cell") {
           handleColumnDrop(sourceData, rawTargetData as ColumnDropData);
 

--- a/packages/react-designer/src/components/editor.css
+++ b/packages/react-designer/src/components/editor.css
@@ -106,16 +106,15 @@
   }
 
   /*
-   * Extend the column wrapper's drop hit area when the column sits at the
-   * very top or bottom of the editor. Without this, an edge column has no
-   * drop target above/below it, so users cannot drop new blocks there or
-   * reorder existing blocks past it. Padding is part of getBoundingClientRect,
-   * so pragmatic-drag-and-drop picks up the cursor in this area and the
-   * existing EDGE_ZONE logic in SortableItemWrapper renders the top/bottom
-   * drop indicator. Only applied when the column is the first/last child so
-   * mid-document layout is unchanged.
+   * Reserve a drop "strip" at the very top of the first column and the very
+   * bottom of the last column, so blocks can be dropped before/after a column
+   * that sits at the start/end of the document (where there is no neighbouring
+   * block to drop next to). Columns in the middle of the document route their
+   * entire body to the cells, so they intentionally get no strip. Padding is
+   * part of getBoundingClientRect, so pragmatic-drag-and-drop picks up the
+   * cursor here and SortableItemWrapper renders the top/bottom drop indicator.
+   * This is editor-only chrome and does not affect the exported email layout.
    */
-
   & > .react-renderer.node-column:first-child
     .draggable-item[data-node-type="column"] {
     padding-top: 24px;
@@ -124,6 +123,30 @@
   & > .react-renderer.node-column:last-child
     .draggable-item[data-node-type="column"] {
     padding-bottom: 24px;
+  }
+
+  /*
+   * When two columns are stacked directly on top of each other, reserve a strip
+   * in the gap between them (the bottom of the upper column and the top of the
+   * lower column) so a block can be dropped BETWEEN the two columns. Without
+   * this, both columns route their whole body to their cells and the gap has no
+   * drop target. Editor-only chrome; does not affect the exported email layout.
+   */
+  & > .react-renderer.node-column:has(+ .react-renderer.node-column)
+    .draggable-item[data-node-type="column"] {
+    padding-bottom: 3px;
+  }
+
+  & > .react-renderer.node-column + .react-renderer.node-column
+    .draggable-item[data-node-type="column"] {
+    padding-top: 3px;
+  }
+
+  /* Collapse the default inter-block margin between two adjacent columns so the
+     gap is just the two 3px strips above (~6px total, contiguous and hittable)
+     instead of margin + strips. */
+  & > .react-renderer.node-column + .react-renderer.node-column {
+    margin-top: 0;
   }
 
   /* Prevent hover effects on elements inside column cells */

--- a/packages/react-designer/src/components/ui/SortableItemWrapper/SortableItemWrapper.tsx
+++ b/packages/react-designer/src/components/ui/SortableItemWrapper/SortableItemWrapper.tsx
@@ -30,6 +30,7 @@ import { readOnlyAtom } from "../../TemplateEditor/store";
 import { Handle } from "../Handle";
 import { selectedNodeAtom } from "../TextMenu/store";
 import { DropIndicatorPlaceholder } from "../DropIndicatorPlaceholder";
+import { resolveColumnDropZone } from "./resolveColumnDropZone";
 
 export interface SortableItemWrapperProps extends NodeViewWrapperProps {
   children: React.ReactNode;
@@ -75,11 +76,14 @@ export const SortableItemWrapper = ({
   const bottomEdgeClearTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const lastMouseYRef = useRef<number | null>(null);
   const mouseMoveCleanupRef = useRef<(() => void) | null>(null);
-  // Cached "natural" column rect for the EDGE_ZONE check. Captured whenever
-  // no indicator is rendered on this wrapper (edge is null). While an edge is
-  // active we keep using this rect to avoid indicator flicker caused by local
-  // layout shifts during drag (e.g. neighboring indicators appearing/disappearing).
-  const stableColumnRectRef = useRef<DOMRect | null>(null);
+  // Cached vertical band (top/bottom) covered by a column's cells. Used to
+  // decide whether the cursor is over the cells (cells own the drop) or in the
+  // column's padding strips above/below the cells (drop before/after column).
+  // Captured whenever no indicator is rendered on this wrapper (edge is null).
+  // While an edge is active we keep using the cached band to avoid indicator
+  // flicker caused by local layout shifts during drag (e.g. neighboring
+  // indicators appearing/disappearing and shifting the cells).
+  const stableCellBandRef = useRef<{ top: number; bottom: number } | null>(null);
   const isReadOnly = useAtomValue(readOnlyAtom);
   const mounted = useMountStatus();
   const mountedWhileDragging = isDragging && !mounted;
@@ -265,38 +269,73 @@ export const SortableItemWrapper = ({
             cellIndex: parentIsColumnCell ? info?.parent?.attrs.index : undefined,
           };
 
-          // Check if this is a column and if we are in the "safe zone" (edges)
-          // We want to disable the main editor drag indicator when dragging inside a column (over cells)
-          // but allow it when dragging over the top/bottom edges of the column itself.
+          // Columns own two distinct drop systems that must not overlap (cells
+          // vs. before/after the whole column). The decision is delegated to the
+          // pure resolveColumnDropZone helper; see its docs for the rules.
           const isColumn = targetElement.getAttribute("data-node-type") === "column";
           if (isColumn) {
-            // Use a cached "natural" rect for the EDGE_ZONE check. If this
-            // wrapper's layout shifts while hovering (because indicators in
-            // nearby blocks appear/disappear), recomputing from the live rect
-            // makes edge distances jump and the indicator gets cleared.
-            // Keeping the cached rect for the current hover session stabilizes
-            // top/bottom detection.
-            const liveRect = targetElement.getBoundingClientRect();
+            const parentNode = info?.parent ?? null;
+            const isRootColumn = parentNode === editor.state.doc;
+            const columnIndex = info?.index ?? -1;
+            const siblingCount = parentNode?.childCount ?? 0;
+
+            const prevSibling =
+              parentNode && columnIndex > 0 ? parentNode.child(columnIndex - 1) : null;
+            const nextSibling =
+              parentNode && columnIndex >= 0 && columnIndex < siblingCount - 1
+                ? parentNode.child(columnIndex + 1)
+                : null;
+            const prevIsColumn = prevSibling?.type.name === "column";
+            const nextIsColumn = nextSibling?.type.name === "column";
+
+            // Cache the cells' band while no edge is active to keep detection
+            // stable when indicators appearing/disappearing shift the layout.
             if (lastEdgeRef.current === null) {
-              stableColumnRectRef.current = liveRect;
+              const cellEls = targetElement.querySelectorAll("[data-column-cell]");
+              if (cellEls.length > 0) {
+                let top = Infinity;
+                let bottom = -Infinity;
+                cellEls.forEach((cellEl) => {
+                  const rect = (cellEl as HTMLElement).getBoundingClientRect();
+                  top = Math.min(top, rect.top);
+                  bottom = Math.max(bottom, rect.bottom);
+                });
+                stableCellBandRef.current = { top, bottom };
+              }
             }
-            const stableRect = stableColumnRectRef.current ?? liveRect;
 
-            const mouseY = input.clientY;
-            const EDGE_ZONE = 30; // pixels from top/bottom to allow main editor drop
+            const zone = resolveColumnDropZone({
+              isRootColumn,
+              columnIndex,
+              siblingCount,
+              prevIsColumn,
+              nextIsColumn,
+              mouseY: input.clientY,
+              cellBand: stableCellBandRef.current,
+            });
 
-            const distTop = Math.abs(mouseY - stableRect.top);
-            const distBottom = Math.abs(mouseY - stableRect.bottom);
-            const inMiddle = distTop > EDGE_ZONE && distBottom > EDGE_ZONE;
-
-            // If we are in the middle (outside edge zones), do not attach edge data
-            // This prevents the visual indicator from appearing and "disables" edge-based reordering
-            if (inMiddle) {
+            if (zone === "before") {
+              return attachClosestEdge(data, {
+                input,
+                element: targetElement,
+                allowedEdges: ["top"],
+              });
+            }
+            if (zone === "after") {
+              return attachClosestEdge(data, {
+                input,
+                element: targetElement,
+                allowedEdges: ["bottom"],
+              });
+            }
+            if (zone === "into-cells") {
               return {
                 ...data,
                 disableDropIndicator: true,
               };
             }
+            // zone === "fallthrough": cells not measured yet → continue to the
+            // generic edge logic below.
           }
 
           // Check if this element is INSIDE a column cell
@@ -378,9 +417,14 @@ export const SortableItemWrapper = ({
             return;
           }
 
-          // Check if drop indicator is disabled (e.g. inside Column center)
+          // Drop indicator disabled (e.g. cursor over a column's cells). Reset
+          // the edge tracking so the cells' band is recomputed and the
+          // before/after-column indicator can re-appear when the cursor returns
+          // to a padding strip.
           if (self.data.disableDropIndicator) {
             setClosestEdge(null);
+            bottomEdgeStableRef.current = false;
+            lastEdgeRef.current = null;
             return;
           }
 
@@ -398,30 +442,17 @@ export const SortableItemWrapper = ({
             bottomEdgeClearTimeoutRef.current = null;
           }
 
-          // Check for nested drop targets (Issue 1 fix)
+          // If a nested drop target is foremost (e.g. a column cell under the
+          // cursor), let it own the drop and hide our own indicator. Columns
+          // only attach an edge when the cursor is in their padding strips,
+          // where the column wrapper itself is the foremost target, so this
+          // never suppresses a legitimate before/after-column indicator.
           const dropTargets = location.current.dropTargets;
           if (dropTargets.length > 0 && dropTargets[0].element !== element) {
-            // For column wrappers: when the cursor is in our EDGE_ZONE, the
-            // column's getData attaches an edge. The cursor is always also
-            // over one of our own cells (which is innermost and therefore
-            // foremost in the dropTargets list). Without this exception the
-            // user could never drop above/below a column when adjacent blocks
-            // exist, because the cell would always preempt the column edge.
-            const isColumnSelf = element?.getAttribute("data-node-type") === "column";
-            const foremostElement = dropTargets[0].element;
-            const nestedInsideSelf = isColumnSelf && element.contains(foremostElement);
-            const ownEdge = extractClosestEdge(self.data);
-
-            if (!(nestedInsideSelf && ownEdge !== null)) {
-              // We are overlapping with a nested target (which is foremost)
-              // Hide our indicator
-              setClosestEdge(null);
-              // Also clear any stable bottom edge
-              bottomEdgeStableRef.current = false;
-              lastEdgeRef.current = null;
-              return;
-            }
-            // Otherwise: column-edge wins over its own cell; fall through.
+            setClosestEdge(null);
+            bottomEdgeStableRef.current = false;
+            lastEdgeRef.current = null;
+            return;
           }
 
           const edge = extractClosestEdge(self.data);
@@ -533,9 +564,14 @@ export const SortableItemWrapper = ({
             return;
           }
 
-          // Check if drop indicator is disabled (e.g. inside Column center)
+          // Drop indicator disabled (e.g. cursor over a column's cells). Reset
+          // the edge tracking so the cells' band is recomputed and the
+          // before/after-column indicator can re-appear when the cursor returns
+          // to a padding strip.
           if (self.data.disableDropIndicator) {
             setClosestEdge(null);
+            bottomEdgeStableRef.current = false;
+            lastEdgeRef.current = null;
             return;
           }
 
@@ -553,23 +589,13 @@ export const SortableItemWrapper = ({
             bottomEdgeClearTimeoutRef.current = null;
           }
 
-          // Check for nested drop targets (Issue 1 fix)
+          // If a nested drop target is foremost (e.g. a column cell under the
+          // cursor), let it own the drop and hide our own indicator. See
+          // onDragEnter for the rationale.
           const dropTargets = location.current.dropTargets;
           if (dropTargets.length > 0 && dropTargets[0].element !== element) {
-            // See onDragEnter for rationale: keep the column's edge when the
-            // foremost is one of our own cells AND the cursor is in our
-            // EDGE_ZONE. This lets the user drop above/below a column even
-            // when its cells fully cover the wrapper.
-            const isColumnSelf = element?.getAttribute("data-node-type") === "column";
-            const foremostElement = dropTargets[0].element;
-            const nestedInsideSelf = isColumnSelf && element.contains(foremostElement);
-            const ownEdge = extractClosestEdge(self.data);
-
-            if (!(nestedInsideSelf && ownEdge !== null)) {
-              setClosestEdge(null);
-              return;
-            }
-            // Otherwise: column-edge wins over its own cell; fall through.
+            setClosestEdge(null);
+            return;
           }
 
           // Get real-time mouse position from the event
@@ -686,7 +712,7 @@ export const SortableItemWrapper = ({
             bottomEdgeClearTimeoutRef.current = setTimeout(() => {
               bottomEdgeStableRef.current = false;
               lastEdgeRef.current = null;
-              stableColumnRectRef.current = null;
+              stableCellBandRef.current = null;
               setClosestEdge(null);
               setDragType(null);
               bottomEdgeClearTimeoutRef.current = null;
@@ -699,7 +725,7 @@ export const SortableItemWrapper = ({
             }
             bottomEdgeStableRef.current = false;
             lastEdgeRef.current = null;
-            stableColumnRectRef.current = null;
+            stableCellBandRef.current = null;
             setClosestEdge(null);
             setDragType(null);
           }
@@ -713,7 +739,7 @@ export const SortableItemWrapper = ({
           // Reset bottom edge stability
           bottomEdgeStableRef.current = false;
           lastEdgeRef.current = null;
-          stableColumnRectRef.current = null;
+          stableCellBandRef.current = null;
           setClosestEdge(null);
           setDragType(null);
         },

--- a/packages/react-designer/src/components/ui/SortableItemWrapper/resolveColumnDropZone.test.ts
+++ b/packages/react-designer/src/components/ui/SortableItemWrapper/resolveColumnDropZone.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import {
+  columnStripsAllowed,
+  resolveColumnDropZone,
+  type ResolveColumnDropZoneArgs,
+} from "./resolveColumnDropZone";
+
+const band = { top: 100, bottom: 300 };
+
+const base: ResolveColumnDropZoneArgs = {
+  isRootColumn: true,
+  columnIndex: 1,
+  siblingCount: 3,
+  prevIsColumn: false,
+  nextIsColumn: false,
+  mouseY: 200,
+  cellBand: band,
+};
+
+describe("columnStripsAllowed", () => {
+  it("allows top strip for the first column", () => {
+    const result = columnStripsAllowed({
+      isRootColumn: true,
+      columnIndex: 0,
+      siblingCount: 3,
+      prevIsColumn: false,
+      nextIsColumn: false,
+    });
+    expect(result.allowTopStrip).toBe(true);
+    expect(result.allowBottomStrip).toBe(false);
+  });
+
+  it("allows bottom strip for the last column", () => {
+    const result = columnStripsAllowed({
+      isRootColumn: true,
+      columnIndex: 2,
+      siblingCount: 3,
+      prevIsColumn: false,
+      nextIsColumn: false,
+    });
+    expect(result.allowTopStrip).toBe(false);
+    expect(result.allowBottomStrip).toBe(true);
+  });
+
+  it("allows both strips for a single column (first and last)", () => {
+    const result = columnStripsAllowed({
+      isRootColumn: true,
+      columnIndex: 0,
+      siblingCount: 1,
+      prevIsColumn: false,
+      nextIsColumn: false,
+    });
+    expect(result.allowTopStrip).toBe(true);
+    expect(result.allowBottomStrip).toBe(true);
+  });
+
+  it("allows top strip when the previous sibling is a column", () => {
+    const result = columnStripsAllowed({
+      isRootColumn: true,
+      columnIndex: 1,
+      siblingCount: 3,
+      prevIsColumn: true,
+      nextIsColumn: false,
+    });
+    expect(result.allowTopStrip).toBe(true);
+  });
+
+  it("allows bottom strip when the next sibling is a column", () => {
+    const result = columnStripsAllowed({
+      isRootColumn: true,
+      columnIndex: 1,
+      siblingCount: 3,
+      prevIsColumn: false,
+      nextIsColumn: true,
+    });
+    expect(result.allowBottomStrip).toBe(true);
+  });
+
+  it("never allows strips for a non-root column", () => {
+    const result = columnStripsAllowed({
+      isRootColumn: false,
+      columnIndex: 0,
+      siblingCount: 1,
+      prevIsColumn: true,
+      nextIsColumn: true,
+    });
+    expect(result.allowTopStrip).toBe(false);
+    expect(result.allowBottomStrip).toBe(false);
+  });
+});
+
+describe("resolveColumnDropZone", () => {
+  describe("middle column between non-columns", () => {
+    it("routes into cells regardless of cursor position", () => {
+      expect(resolveColumnDropZone({ ...base, mouseY: 0 })).toBe("into-cells");
+      expect(resolveColumnDropZone({ ...base, mouseY: 200 })).toBe("into-cells");
+      expect(resolveColumnDropZone({ ...base, mouseY: 1000 })).toBe("into-cells");
+    });
+
+    it("routes into cells even when the band is unknown", () => {
+      expect(resolveColumnDropZone({ ...base, cellBand: null })).toBe("into-cells");
+    });
+  });
+
+  describe("first column", () => {
+    const first: ResolveColumnDropZoneArgs = {
+      ...base,
+      columnIndex: 0,
+      siblingCount: 3,
+    };
+
+    it("drops before when above the cell band", () => {
+      expect(resolveColumnDropZone({ ...first, mouseY: band.top - 5 })).toBe("before");
+    });
+
+    it("routes into cells when over the band", () => {
+      expect(resolveColumnDropZone({ ...first, mouseY: 200 })).toBe("into-cells");
+    });
+
+    it("routes into cells below the band (bottom strip not allowed)", () => {
+      expect(resolveColumnDropZone({ ...first, mouseY: band.bottom + 5 })).toBe("into-cells");
+    });
+  });
+
+  describe("last column", () => {
+    const last: ResolveColumnDropZoneArgs = {
+      ...base,
+      columnIndex: 2,
+      siblingCount: 3,
+    };
+
+    it("drops after when below the cell band", () => {
+      expect(resolveColumnDropZone({ ...last, mouseY: band.bottom + 5 })).toBe("after");
+    });
+
+    it("routes into cells when over the band", () => {
+      expect(resolveColumnDropZone({ ...last, mouseY: 200 })).toBe("into-cells");
+    });
+
+    it("routes into cells above the band (top strip not allowed)", () => {
+      expect(resolveColumnDropZone({ ...last, mouseY: band.top - 5 })).toBe("into-cells");
+    });
+  });
+
+  describe("single column (first and last)", () => {
+    const single: ResolveColumnDropZoneArgs = {
+      ...base,
+      columnIndex: 0,
+      siblingCount: 1,
+    };
+
+    it("drops before above the band", () => {
+      expect(resolveColumnDropZone({ ...single, mouseY: band.top - 5 })).toBe("before");
+    });
+
+    it("drops after below the band", () => {
+      expect(resolveColumnDropZone({ ...single, mouseY: band.bottom + 5 })).toBe("after");
+    });
+
+    it("routes into cells over the band", () => {
+      expect(resolveColumnDropZone({ ...single, mouseY: 200 })).toBe("into-cells");
+    });
+  });
+
+  describe("between two stacked columns", () => {
+    it("offers before for the lower column (prevIsColumn) above its band", () => {
+      const lower: ResolveColumnDropZoneArgs = {
+        ...base,
+        columnIndex: 1,
+        siblingCount: 3,
+        prevIsColumn: true,
+      };
+      expect(resolveColumnDropZone({ ...lower, mouseY: band.top - 2 })).toBe("before");
+    });
+
+    it("offers after for the upper column (nextIsColumn) below its band", () => {
+      const upper: ResolveColumnDropZoneArgs = {
+        ...base,
+        columnIndex: 1,
+        siblingCount: 3,
+        nextIsColumn: true,
+      };
+      expect(resolveColumnDropZone({ ...upper, mouseY: band.bottom + 2 })).toBe("after");
+    });
+  });
+
+  describe("band not yet measured", () => {
+    it("falls through when a strip is allowed but the band is null", () => {
+      expect(
+        resolveColumnDropZone({ ...base, columnIndex: 0, siblingCount: 3, cellBand: null })
+      ).toBe("fallthrough");
+    });
+  });
+});

--- a/packages/react-designer/src/components/ui/SortableItemWrapper/resolveColumnDropZone.ts
+++ b/packages/react-designer/src/components/ui/SortableItemWrapper/resolveColumnDropZone.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure decision logic for how a drag should be routed when the cursor is over a
+ * Column wrapper. A Column hosts two distinct drop systems that must never
+ * overlap:
+ *   1. Its cells accept drops INTO the column.
+ *   2. The wrapper itself accepts drops BEFORE/AFTER the whole column.
+ *
+ * To avoid the ambiguity that previously let a drop land before a column while
+ * a cell looked targeted, the column body always routes to the cells. A
+ * before/after-column drop is only offered where there is a genuine reason to
+ * drop next to the column:
+ *   - the column is the FIRST/LAST top-level block (drop at the very start/end
+ *     of the document), or
+ *   - the adjacent top-level block is ALSO a column (so a block can be inserted
+ *     in the gap between two stacked columns).
+ *
+ * This is extracted as a pure function so the branching can be unit-tested
+ * without a live editor / DOM.
+ */
+
+export interface ColumnCellBand {
+  /** Top edge (clientY) of the topmost cell. */
+  top: number;
+  /** Bottom edge (clientY) of the bottommost cell. */
+  bottom: number;
+}
+
+export interface ResolveColumnDropZoneArgs {
+  /** Whether the column is a direct child of the document (top level). */
+  isRootColumn: boolean;
+  /** Index of the column among its siblings. */
+  columnIndex: number;
+  /** Number of siblings in the column's parent. */
+  siblingCount: number;
+  /** Whether the previous sibling is also a column. */
+  prevIsColumn: boolean;
+  /** Whether the next sibling is also a column. */
+  nextIsColumn: boolean;
+  /** Current cursor Y (clientY). */
+  mouseY: number;
+  /** Measured vertical band covered by the column's cells, if known. */
+  cellBand: ColumnCellBand | null;
+}
+
+export type ColumnDropZone =
+  /** Drop before the whole column (top edge). */
+  | "before"
+  /** Drop after the whole column (bottom edge). */
+  | "after"
+  /** Let the cell drop targets own the drop (no column indicator). */
+  | "into-cells"
+  /** Cell band not measured yet — caller should fall back to generic logic. */
+  | "fallthrough";
+
+/** Returns whether the top/bottom before-after strips should be offered. */
+export const columnStripsAllowed = ({
+  isRootColumn,
+  columnIndex,
+  siblingCount,
+  prevIsColumn,
+  nextIsColumn,
+}: Pick<
+  ResolveColumnDropZoneArgs,
+  "isRootColumn" | "columnIndex" | "siblingCount" | "prevIsColumn" | "nextIsColumn"
+>): { allowTopStrip: boolean; allowBottomStrip: boolean } => {
+  const allowTopStrip = isRootColumn && (columnIndex === 0 || prevIsColumn);
+  const allowBottomStrip = isRootColumn && (columnIndex === siblingCount - 1 || nextIsColumn);
+  return { allowTopStrip, allowBottomStrip };
+};
+
+export const resolveColumnDropZone = (args: ResolveColumnDropZoneArgs): ColumnDropZone => {
+  const { mouseY, cellBand } = args;
+  const { allowTopStrip, allowBottomStrip } = columnStripsAllowed(args);
+
+  // No strip is offered → the whole body (incl. padding) belongs to the cells.
+  if (!allowTopStrip && !allowBottomStrip) {
+    return "into-cells";
+  }
+
+  // A strip is allowed but we have not measured the cells yet → defer to the
+  // caller's generic edge logic.
+  if (!cellBand) {
+    return "fallthrough";
+  }
+
+  if (allowTopStrip && mouseY < cellBand.top) {
+    return "before";
+  }
+  if (allowBottomStrip && mouseY > cellBand.bottom) {
+    return "after";
+  }
+  // Cursor is over the cells (or in a strip that is not allowed on this side).
+  return "into-cells";
+};


### PR DESCRIPTION
## Description

Refactors the drag-and-drop logic around `Column` elements so drops are deterministic. Previously, dragging a block over a column cell showed the correct cell highlight, but on drop the block was inserted **before** the column (most reliably when the cursor was near the top of the column) because the column wrapper's fixed edge zone overlapped the cells' own drop targets.

- Extracts the column drop-zone decision into a pure `resolveColumnDropZone` helper (cells vs. before/after the whole column).
- The column body now always routes to its cells; a before/after-column drop is only offered at the document start/end or between two adjacent columns.
- Enables dropping a block into the gap between two vertically stacked columns.
- Removes the `usePragmaticDnd.onDrop` reroute that favored the column edge over a foremost cell target.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Config/infra change
- [ ] Docs or guidelines

## Test Plan

- Unit: `resolveColumnDropZone.test.ts` covers every branch (middle/first/last/single column, prev/next-is-column, cursor above/within/below the cell band, band-not-measured fallthrough). Full package suite passes.
- E2E: `column-drag-and-drop.spec.ts` adds cases for dropping at a cell's top (lands in the cell) and dropping in the gap between two stacked columns (lands between them). All 9 column DnD e2e tests pass.

## Risk

YELLOW

## Related issues

Closes C-18786

## Additional checklist

- [x] Changes have been manually tested
- [x] Changeset added (if needed for publishing)

Made with [Cursor](https://cursor.com)