### PR TITLE
[C-19008] Fix crash when editing quote blocks in localization panel

### DIFF
--- a/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
+++ b/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
@@ -667,7 +667,10 @@ export function convertElementalToTiptap(
 
       case "quote": {
         // Helper to detect if content is a markdown-style list
-        const isListContent = (content: string): { isList: boolean; isOrdered: boolean } => {
+        const isListContent = (
+          content: string | undefined
+        ): { isList: boolean; isOrdered: boolean } => {
+          if (!content) return { isList: false, isOrdered: false };
           const lines = content.split("\n").filter((l) => l.trim());
           if (lines.length === 0) return { isList: false, isOrdered: false };
 
@@ -719,14 +722,15 @@ export function convertElementalToTiptap(
         };
 
         // Check if content is a list
-        const listInfo = isListContent(node.content);
+        const quoteContent = node.content ?? "";
+        const listInfo = isListContent(quoteContent);
 
         // Build blockquote content
         let blockquoteContent: TiptapNode[];
 
         if (listInfo.isList) {
           // Content is a list - convert to list node
-          blockquoteContent = parseListContent(node.content, listInfo.isOrdered);
+          blockquoteContent = parseListContent(quoteContent, listInfo.isOrdered);
         } else {
           // Regular text content
           // Determine the child node type based on text_style
@@ -757,7 +761,7 @@ export function convertElementalToTiptap(
             {
               type: childType,
               attrs: childAttrs,
-              content: parseMDContent(node.content),
+              content: quoteContent.trim() ? parseMDContent(quoteContent) : [],
             },
           ];
         }


### PR DESCRIPTION
## Summary
- Add null guard in `isListContent` for undefined quote `content` — prevents `Cannot read properties of undefined (reading 'split')` crash
- Normalize all `node.content` references in the quote case through a `quoteContent` variable with `?? ""` fallback
- Handle empty content gracefully by returning empty array instead of calling `parseMDContent`

## Root cause
The localization editor's `updateSourceInlineElements` was converting quote nodes to inline-elements format (setting `elements`, deleting `content`). When the designer then tried to render this malformed quote node, `isListContent(node.content)` crashed because `node.content` was `undefined`.

The frontend fix (companion PR in courier/frontend) prevents quote nodes from being incorrectly mutated. This designer fix adds defensive null guards so even malformed data doesn't crash the editor.

## Test plan
- [x] All 2724 existing tests pass
- [ ] Create a quote element with text
- [ ] Open the localization panel and edit the quote source text
- [ ] Verify no crash occurs when navigating back to designer

🤖 Generated with [Claude Code](https://claude.com/claude-code)