### PR TITLE
feat(liquid): add Liquid rendering engine support (C-19022)

### DIFF
--- a/.changeset/liquid-rendering-engine.md
+++ b/.changeset/liquid-rendering-engine.md
@@ -1,0 +1,5 @@
+---
+"@trycourier/react-designer": minor
+---
+
+Add Liquid rendering engine support. `TemplateEditor` accepts a controlled `renderEngine` prop that persists to the content's `render_options.engine`. Under Liquid, `{{ }}` variables validate with filters, bracket indexing, and the `data.` namespace, autocomplete inserts `data.*`, and saved tokens use `{{ data.name }}` spacing. Liquid `{% %}` control-flow tags render as distinct chips (no validation; round-trip verbatim). Pressing Enter on a selected variable/tag chip now enters edit mode. Handlebars remains the default and is unchanged.

--- a/apps/editor-dev/src/pages/BasicPage.tsx
+++ b/apps/editor-dev/src/pages/BasicPage.tsx
@@ -1,4 +1,6 @@
 import { TemplateEditor } from "@trycourier/react-designer";
+import { useOutletContext } from "react-router-dom";
+import type { LayoutContext } from "./Layout";
 
 const SAMPLE_DATA = {
   data: {
@@ -17,6 +19,8 @@ const SAMPLE_DATA = {
  * Basic TemplateEditor demo with default configuration.
  */
 export function BasicPage() {
+  const { renderEngine, onRenderEngineChange } = useOutletContext<LayoutContext>();
+
   return (
     <TemplateEditor
       routing={{
@@ -25,6 +29,8 @@ export function BasicPage() {
       }}
       brandEditor
       sampleData={SAMPLE_DATA}
+      renderEngine={renderEngine}
+      onRenderEngineChange={onRenderEngineChange}
     />
   );
 }

--- a/apps/editor-dev/src/pages/Layout.tsx
+++ b/apps/editor-dev/src/pages/Layout.tsx
@@ -1,6 +1,8 @@
-import { TemplateProvider } from "@trycourier/react-designer";
-import { useState } from "react";
+import { TemplateProvider, type RenderEngine } from "@trycourier/react-designer";
+import { useEffect, useState } from "react";
 import { NavLink, Outlet } from "react-router-dom";
+
+const RenderEngines: RenderEngine[] = ["handlebars", "liquid"];
 
 const TenantIds = [import.meta.env.VITE_TENANT_ID || "test-tenant", "frodo"];
 const TemplateIds = [
@@ -27,6 +29,15 @@ export function Layout() {
   const [tenantId, setTenantId] = useState(TenantIds[0]);
   const [templateId, setTemplateId] = useState(TemplateIds[0]);
   const [availableTemplates, setAvailableTemplates] = useState(TemplateIds);
+  // Undefined = uncontrolled: let the editor hydrate the engine from the loaded
+  // template and report it back via onRenderEngineChange. A value here means the
+  // user picked one (controlled). Reset on tenant/template switch so the next
+  // template re-hydrates.
+  const [renderEngine, setRenderEngine] = useState<RenderEngine | undefined>(undefined);
+
+  useEffect(() => {
+    setRenderEngine(undefined);
+  }, [tenantId, templateId]);
 
   // Callback to add newly created templates to the dropdown
   const handleTemplateCreated = (newTemplateId: string) => {
@@ -92,6 +103,27 @@ export function Layout() {
             ))}
           </select>
         </label>
+        <label>
+          Engine:{" "}
+          {/* Until the editor reports the loaded template's engine, renderEngine
+              is undefined: show a disabled "Loading…" state and don't let the
+              user change anything. */}
+          <select
+            value={renderEngine ?? ""}
+            disabled={renderEngine === undefined}
+            onChange={(e) => setRenderEngine(e.target.value as RenderEngine)}
+          >
+            {renderEngine === undefined ? (
+              <option value="">Loading…</option>
+            ) : (
+              RenderEngines.map((engine) => (
+                <option value={engine} key={engine}>
+                  {engine}
+                </option>
+              ))
+            )}
+          </select>
+        </label>
       </div>
 
       {/* Template Provider wrapping the outlet */}
@@ -102,7 +134,15 @@ export function Layout() {
         apiUrl={import.meta.env.VITE_API_URL || "https://api.courier.com/client/q"}
         variables={{}}
       >
-        <Outlet context={{ templateId, tenantId, handleTemplateCreated }} />
+        <Outlet
+          context={{
+            templateId,
+            tenantId,
+            renderEngine,
+            onRenderEngineChange: setRenderEngine,
+            handleTemplateCreated,
+          }}
+        />
       </TemplateProvider>
     </div>
   );
@@ -112,5 +152,8 @@ export function Layout() {
 export interface LayoutContext {
   templateId: string;
   tenantId: string;
+  /** Undefined until the editor reports the loaded template's engine. */
+  renderEngine: RenderEngine | undefined;
+  onRenderEngineChange: (engine: RenderEngine) => void;
   handleTemplateCreated: (templateId: string) => void;
 }

--- a/packages/react-designer/src/components/Providers/api/template.ts
+++ b/packages/react-designer/src/components/Providers/api/template.ts
@@ -17,9 +17,48 @@ import {
   templateEditorContentAtom,
   templateEditorPublishedAtAtom,
   templateEditorVersionAtom,
+  renderEngineAtom,
+  DEFAULT_RENDER_ENGINE,
 } from "@/components/TemplateEditor/store";
 import { cleanTemplateContent } from "@/lib/utils/getTitle/preserveStorageFormat";
-import type { ElementalContent } from "@/types";
+import { normalizeVariableSpacing } from "@/lib/utils/normalizeVariableSpacing";
+import { coalesceTextRuns } from "@/lib/utils/coalesceTextRuns";
+import type { ElementalContent, RenderEngine } from "@/types";
+
+/**
+ * Prepares content for the chosen engine. Under Liquid: coalesces each text run
+ * into a single `string` (so a `{% if %}…{% endif %}` block lives in one
+ * interpolation field instead of being split across elements), normalizes
+ * variable-token spacing (`{{ x }}`), and writes `render_options.engine`.
+ * Under Handlebars (the default), the content is left byte-for-byte unchanged
+ * UNLESS it currently declares `engine: "liquid"` — in which case the marker is
+ * removed (the user switched back), preserving any other `render_options` keys.
+ * Existing Handlebars content (no engine, `{}`, or `engine: "handlebars"`) is
+ * untouched.
+ */
+function applyRenderEngine(content: ElementalContent, engine: RenderEngine): ElementalContent {
+  if (engine !== DEFAULT_RENDER_ENGINE) {
+    const merged = coalesceTextRuns(content);
+    const spaced = normalizeVariableSpacing(merged, engine);
+    return { ...spaced, render_options: { ...spaced.render_options, engine } };
+  }
+
+  const spaced = normalizeVariableSpacing(content, engine);
+
+  // Handlebars: only mutate render_options if it currently claims Liquid; never
+  // touch content that already lacks an engine marker.
+  if (spaced.render_options?.engine !== "liquid") {
+    return spaced;
+  }
+
+  const { engine: _omit, ...restOptions } = spaced.render_options;
+  if (Object.keys(restOptions).length > 0) {
+    return { ...spaced, render_options: restOptions };
+  }
+
+  const { render_options: _drop, ...rest } = spaced;
+  return rest;
+}
 
 // Interface for save options
 export interface SaveTemplateOptions {
@@ -95,8 +134,12 @@ export const saveTemplateAtom = atom(
       return;
     }
 
-    // Apply the same cleaning logic as auto-save for ALL channels
-    const templateEditorContent = cleanTemplateContent(rawTemplateEditorContent);
+    // Apply the same cleaning logic as auto-save for ALL channels, then stamp
+    // the selected rendering engine into render_options.
+    const templateEditorContent = applyRenderEngine(
+      cleanTemplateContent(rawTemplateEditorContent),
+      get(renderEngineAtom)
+    );
 
     if (!apiUrl) {
       set(templateErrorAtom, { message: "Missing API URL", toastProps: { duration: 5000 } });
@@ -313,7 +356,10 @@ export const duplicateTemplateAtom = atom(
     // the getTemplate effect in TemplateEditor, causing a loop when auth fails.
 
     // Clean the content before saving
-    const templateContent = cleanTemplateContent(rawContent);
+    const templateContent = applyRenderEngine(
+      cleanTemplateContent(rawContent),
+      get(renderEngineAtom)
+    );
 
     const data = {
       content: templateContent,

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Email/Email.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Email/Email.test.tsx
@@ -210,6 +210,7 @@ vi.mock("jotai", async () => {
       if (atom === "visibleBlocksAtom") return mockVisibleBlocks;
       if (atom === "blockPresetsAtom") return mockBlockPresets;
       if (atom === "blockDefaultsAtom") return mockBlockDefaults;
+      if (atom === "renderEngineAtom") return undefined;
       return null;
     }),
     useSetAtom: vi.fn(() => vi.fn()),
@@ -250,6 +251,7 @@ vi.mock("../../store", () => ({
   EMAIL_DEFAULT_CONTENT_BODY_COLOR: "#ffffff",
   EMAIL_EDITOR_FONT_FAMILY: "Inter, sans-serif",
   previewLocaleAtom: "previewLocaleAtom",
+  renderEngineAtom: "renderEngineAtom",
 }));
 
 vi.mock("@/components/ui/TextMenu/store", () => ({
@@ -1301,12 +1303,10 @@ describe("Email Component", () => {
             child: vi.fn((index: number) => (index === 0 ? paragraphNode0 : paragraphNode1)),
             content: {
               size: 25,
-              forEach: vi.fn(
-                (cb: (node: MockNode, offset: number, index: number) => void) => {
-                  cb(paragraphNode0, 0, 0);
-                  cb(paragraphNode1, 10, 1);
-                }
-              ),
+              forEach: vi.fn((cb: (node: MockNode, offset: number, index: number) => void) => {
+                cb(paragraphNode0, 0, 0);
+                cb(paragraphNode1, 10, 1);
+              }),
             },
           },
         },
@@ -1364,12 +1364,10 @@ describe("Email Component", () => {
             child: vi.fn((index: number) => (index === 0 ? paragraphNode : headingNode)),
             content: {
               size: 20,
-              forEach: vi.fn(
-                (cb: (node: MockNode, offset: number, index: number) => void) => {
-                  cb(paragraphNode, 0, 0);
-                  cb(headingNode, 12, 1);
-                }
-              ),
+              forEach: vi.fn((cb: (node: MockNode, offset: number, index: number) => void) => {
+                cb(paragraphNode, 0, 0);
+                cb(headingNode, 12, 1);
+              }),
             },
           },
         },
@@ -1426,12 +1424,10 @@ describe("Email Component", () => {
             child: vi.fn((index: number) => (index === 0 ? paragraphNode : imageNode)),
             content: {
               size: 15,
-              forEach: vi.fn(
-                (cb: (node: MockNode, offset: number, index: number) => void) => {
-                  cb(paragraphNode, 0, 0);
-                  cb(imageNode, 10, 1);
-                }
-              ),
+              forEach: vi.fn((cb: (node: MockNode, offset: number, index: number) => void) => {
+                cb(paragraphNode, 0, 0);
+                cb(imageNode, 10, 1);
+              }),
             },
           },
         },
@@ -1485,12 +1481,10 @@ describe("Email Component", () => {
             child: vi.fn((index: number) => (index === 0 ? paragraphNode : imageNode)),
             content: {
               size: 15,
-              forEach: vi.fn(
-                (cb: (node: MockNode, offset: number, index: number) => void) => {
-                  cb(paragraphNode, 0, 0);
-                  cb(imageNode, 10, 1);
-                }
-              ),
+              forEach: vi.fn((cb: (node: MockNode, offset: number, index: number) => void) => {
+                cb(paragraphNode, 0, 0);
+                cb(imageNode, 10, 1);
+              }),
             },
           },
         },
@@ -1557,13 +1551,11 @@ describe("Email Component", () => {
             }),
             content: {
               size: 30,
-              forEach: vi.fn(
-                (cb: (node: MockNode, offset: number, index: number) => void) => {
-                  cb(imageNode, 0, 0);
-                  cb(dividerNode, 6, 1);
-                  cb(paragraphNode, 10, 2);
-                }
-              ),
+              forEach: vi.fn((cb: (node: MockNode, offset: number, index: number) => void) => {
+                cb(imageNode, 0, 0);
+                cb(dividerNode, 6, 1);
+                cb(paragraphNode, 10, 2);
+              }),
             },
           },
         },

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Email/Email.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Email/Email.tsx
@@ -26,6 +26,7 @@ import {
   previewLocaleAtom,
   visibleBlocksAtom,
   getFormUpdating,
+  renderEngineAtom,
   type VisibleBlockItem,
 } from "../../store";
 import type { TemplateEditorProps } from "../../TemplateEditor";
@@ -184,6 +185,7 @@ const EmailComponent = forwardRef<HTMLDivElement, EmailProps>(
     // Add a ref to track if content has been loaded from server
     const contentLoadedRef = useRef(false);
     const templateEditorContent = useAtomValue(templateEditorContentAtom);
+    const renderEngine = useAtomValue(renderEngineAtom);
     const brandEditorContent = useAtomValue(BrandEditorContentAtom);
     const isTemplateTransitioning = useAtomValue(isTemplateTransitioningAtom);
     const visibleBlocks = useAtomValue(visibleBlocksAtom);
@@ -540,8 +542,9 @@ const EmailComponent = forwardRef<HTMLDivElement, EmailProps>(
 
       return convertElementalToTiptap(elementalForConversion, {
         channel: "email",
+        renderEngine,
       });
-    }, [value, isTemplateLoading, showContent, previewLocale]);
+    }, [value, isTemplateLoading, showContent, previewLocale, renderEngine]);
 
     // Prevent rendering during problematic transitions to avoid DOM conflicts
     // Only return null if we're transitioning AND content is null (dangerous state)

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Email/EmailEditor.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Email/EmailEditor.test.tsx
@@ -254,6 +254,7 @@ vi.mock("@/components/TemplateEditor/store", () => ({
   blockDefaultsAtom: "blockDefaultsAtom",
   variablesEnabledAtom: "variablesEnabledAtom",
   previewLocaleAtom: "previewLocaleAtom",
+  renderEngineAtom: "renderEngineAtom",
   getFormUpdating: () => false,
   setFormUpdating: () => {},
 }));

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Email/EmailEditor.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Email/EmailEditor.tsx
@@ -7,6 +7,7 @@ import {
   isDraggingAtom,
   flushFunctionsAtom,
   pendingAutoSaveAtom,
+  renderEngineAtom,
   type VariableViewMode,
   getFormUpdating,
 } from "@/components/TemplateEditor/store";
@@ -72,6 +73,7 @@ const EditorContent = ({ value }: { value?: TiptapDoc }) => {
   const [templateEditorContent, setTemplateEditorContent] = useAtom(templateEditorContentAtom);
   const setPendingAutoSave = useSetAtom(pendingAutoSaveAtom);
   const subject = useAtomValue(subjectAtom);
+  const renderEngine = useAtomValue(renderEngineAtom);
   const selectedNode = useAtomValue(selectedNodeAtom);
   const setTemplateEditor = useSetAtom(templateEditorAtom);
   const setFlushFunctions = useSetAtom(flushFunctionsAtom);
@@ -214,16 +216,19 @@ const EditorContent = ({ value }: { value?: TiptapDoc }) => {
       [];
 
     // Convert to TipTap format
-    const newContent = convertElementalToTiptap({
-      version: "2022-01-01",
-      elements: [
-        {
-          type: "channel" as const,
-          channel: "email" as const,
-          elements: emailElements,
-        },
-      ],
-    });
+    const newContent = convertElementalToTiptap(
+      {
+        version: "2022-01-01",
+        elements: [
+          {
+            type: "channel" as const,
+            channel: "email" as const,
+            elements: emailElements,
+          },
+        ],
+      },
+      { renderEngine }
+    );
 
     const incomingContent = convertTiptapToElemental(newContent);
     const currentContent = convertTiptapToElemental(editor.getJSON() as TiptapDoc);
@@ -250,7 +255,7 @@ const EditorContent = ({ value }: { value?: TiptapDoc }) => {
         }
       }, 1);
     }
-  }, [editor, templateEditorContent]);
+  }, [editor, templateEditorContent, renderEngine]);
 
   useEffect(() => {
     if (!editor || isTemplateLoading !== false || isTemplateTransitioning) {

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.test.tsx
@@ -57,6 +57,9 @@ vi.mock("jotai", () => ({
     if (atomStr.includes("isDragging")) {
       return false;
     }
+    if (atomStr.includes("renderEngine")) {
+      return undefined;
+    }
     return null;
   }),
   useSetAtom: vi.fn(() => vi.fn()),
@@ -77,6 +80,7 @@ vi.mock("@/components/TemplateEditor/store", () => ({
   blockDefaultsAtom: "blockDefaultsAtom",
   variablesEnabledAtom: "variablesEnabledAtom",
   previewLocaleAtom: "previewLocaleAtom",
+  renderEngineAtom: "renderEngineAtom",
   getFormUpdating: () => false,
   setFormUpdating: () => {},
 }));

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.tsx
@@ -8,6 +8,7 @@ import {
   pendingAutoSaveAtom,
   getFormUpdating,
   previewLocaleAtom,
+  renderEngineAtom,
 } from "@/components/TemplateEditor/store";
 import type { TextMenuConfig } from "@/components/ui/TextMenu/config";
 import { selectedNodeAtom } from "@/components/ui/TextMenu/store";
@@ -121,6 +122,7 @@ export const InboxEditorContent = ({ value }: InboxEditorContentProps) => {
   const { editor } = useCurrentEditor();
   const setTemplateEditor = useSetAtom(templateEditorAtom);
   const templateEditorContent = useAtomValue(templateEditorContentAtom);
+  const renderEngine = useAtomValue(renderEngineAtom);
   const isTemplateLoading = useAtomValue(isTemplateLoadingAtom);
   const isValueUpdated = useRef(false);
 
@@ -171,7 +173,7 @@ export const InboxEditorContent = ({ value }: InboxEditorContentProps) => {
         version: "2022-01-01",
         elements: [element],
       },
-      { channel: "inbox" }
+      { channel: "inbox", renderEngine }
     );
 
     const incomingContent = convertTiptapToElemental(newContent);
@@ -187,7 +189,7 @@ export const InboxEditorContent = ({ value }: InboxEditorContentProps) => {
         }
       }, 1);
     }
-  }, [editor, templateEditorContent]);
+  }, [editor, templateEditorContent, renderEngine]);
 
   return null;
 };
@@ -250,6 +252,7 @@ const InboxComponent = forwardRef<HTMLDivElement, InboxProps>(
     const isMountedRef = useRef(false);
     const setSelectedNode = useSetAtom(selectedNodeAtom);
     const [templateEditorContent, setTemplateEditorContent] = useAtom(templateEditorContentAtom);
+    const renderEngine = useAtomValue(renderEngineAtom);
     const setPendingAutoSave = useSetAtom(pendingAutoSaveAtom);
     const isTemplateTransitioning = useAtomValue(isTemplateTransitioningAtom);
 
@@ -359,9 +362,9 @@ const InboxComponent = forwardRef<HTMLDivElement, InboxProps>(
         elements: [element],
       };
 
-      return convertElementalToTiptap(elementalForConversion, { channel: "inbox" });
+      return convertElementalToTiptap(elementalForConversion, { channel: "inbox", renderEngine });
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isTemplateLoading, previewLocale]); // Only recompute when loading state or locale changes - value/templateEditorContent intentionally omitted to keep EditorProvider stable
+    }, [isTemplateLoading, previewLocale, renderEngine]); // Only recompute when loading state, locale, or engine changes - value/templateEditorContent intentionally omitted to keep EditorProvider stable
 
     return (
       <MainLayout

--- a/packages/react-designer/src/components/TemplateEditor/Channels/MSTeams/MSTeams.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/MSTeams/MSTeams.test.tsx
@@ -80,6 +80,7 @@ vi.mock("@/components/TemplateEditor/store", () => ({
   visibleBlocksAtom: "visibleBlocksAtom",
   variablesEnabledAtom: "variablesEnabledAtom",
   previewLocaleAtom: "previewLocaleAtom",
+  renderEngineAtom: "renderEngineAtom",
   isPresetReference: () => false,
   getFormUpdating: () => false,
   setFormUpdating: () => {},
@@ -125,6 +126,9 @@ vi.mock("jotai", () => ({
     }
     if (atom === "visibleBlocksAtom") {
       return mockVisibleBlocks;
+    }
+    if (atom === "renderEngineAtom") {
+      return undefined;
     }
     return null;
   }),
@@ -313,7 +317,8 @@ describe("MSTeams Component", () => {
     mockEditor.isDestroyed = false;
     // Provide requestAnimationFrame for the test environment
     if (!globalThis.requestAnimationFrame) {
-      globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(cb, 0) as unknown as number;
+      globalThis.requestAnimationFrame = (cb: FrameRequestCallback) =>
+        setTimeout(cb, 0) as unknown as number;
       globalThis.cancelAnimationFrame = (id: number) => clearTimeout(id);
     }
   });

--- a/packages/react-designer/src/components/TemplateEditor/Channels/MSTeams/MSTeams.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/MSTeams/MSTeams.tsx
@@ -10,6 +10,7 @@ import {
   isPresetReference,
   getFormUpdating,
   previewLocaleAtom,
+  renderEngineAtom,
   type VisibleBlockItem,
   type BlockElementType,
 } from "@/components/TemplateEditor/store";
@@ -76,6 +77,7 @@ export const MSTeamsEditorContent = ({ value }: { value?: TiptapDoc }) => {
   const { editor } = useCurrentEditor();
   const setTemplateEditor = useSetAtom(templateEditorAtom);
   const templateEditorContent = useAtomValue(templateEditorContentAtom);
+  const renderEngine = useAtomValue(renderEngineAtom);
   const isTemplateLoading = useAtomValue(isTemplateLoadingAtom);
   const selectedNode = useAtomValue(selectedNodeAtom);
   const isValueUpdated = useRef(false);
@@ -141,7 +143,7 @@ export const MSTeamsEditorContent = ({ value }: { value?: TiptapDoc }) => {
         version: "2022-01-01",
         elements: [element],
       },
-      { channel: "msteams" }
+      { channel: "msteams", renderEngine }
     );
 
     const incomingContent = convertTiptapToElemental(newContent);
@@ -157,7 +159,7 @@ export const MSTeamsEditorContent = ({ value }: { value?: TiptapDoc }) => {
         }
       }, 1);
     }
-  }, [editor, templateEditorContent]);
+  }, [editor, templateEditorContent, renderEngine]);
 
   return null;
 };
@@ -350,6 +352,7 @@ const MSTeamsComponent = forwardRef<HTMLDivElement, MSTeamsProps>(
     const [selectedNode, setSelectedNode] = useAtom(selectedNodeAtom);
     const [templateEditorContent, setTemplateEditorContent] = useAtom(templateEditorContentAtom);
     const setPendingAutoSave = useSetAtom(pendingAutoSaveAtom);
+    const renderEngine = useAtomValue(renderEngineAtom);
 
     const previewLocale = useAtomValue(previewLocaleAtom);
     const isInitialLoadRef = useRef(true);
@@ -656,8 +659,11 @@ const MSTeamsComponent = forwardRef<HTMLDivElement, MSTeamsProps>(
           ) as typeof elementalForConversion) ?? elementalForConversion;
       }
 
-      return convertElementalToTiptap(elementalForConversion, { channel: "msteams" });
-    }, [value, previewLocale]);
+      return convertElementalToTiptap(elementalForConversion, {
+        channel: "msteams",
+        renderEngine,
+      });
+    }, [value, previewLocale, renderEngine]);
 
     return (
       <MainLayout

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Push/Push.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Push/Push.test.tsx
@@ -51,6 +51,9 @@ vi.mock("jotai", () => ({
     if (atomStr.includes("isDragging")) {
       return false;
     }
+    if (atomStr.includes("renderEngine")) {
+      return undefined;
+    }
     return null;
   }),
   useSetAtom: vi.fn(() => vi.fn()),
@@ -68,6 +71,7 @@ vi.mock("../../store", () => ({
   isDraggingAtom: "isDraggingAtom",
   pendingAutoSaveAtom: "pendingAutoSaveAtom",
   previewLocaleAtom: "previewLocaleAtom",
+  renderEngineAtom: "renderEngineAtom",
   getFormUpdating: () => false,
   setFormUpdating: () => {},
 }));
@@ -335,19 +339,22 @@ describe("Push Component", () => {
 
       render(<Push routing={routing} render={mockRender} />);
 
-      expect(convertElementalToTiptap).toHaveBeenCalledWith({
-        version: "2022-01-01",
-        elements: [
-          {
-            type: "channel",
-            channel: "push",
-            elements: [
-              { type: "text", content: "\n", text_style: "h2" }, // Empty meta title converts to "\n" for H2
-              { type: "text", content: "\n" },
-            ],
-          },
-        ],
-      });
+      expect(convertElementalToTiptap).toHaveBeenCalledWith(
+        {
+          version: "2022-01-01",
+          elements: [
+            {
+              type: "channel",
+              channel: "push",
+              elements: [
+                { type: "text", content: "\n", text_style: "h2" }, // Empty meta title converts to "\n" for H2
+                { type: "text", content: "\n" },
+              ],
+            },
+          ],
+        },
+        { renderEngine: undefined }
+      );
     });
 
     it("should use existing push content from template", () => {
@@ -377,19 +384,22 @@ describe("Push Component", () => {
 
       render(<Push routing={routing} render={mockRender} value={existingContent} />);
 
-      expect(convertElementalToTiptap).toHaveBeenCalledWith({
-        version: "2022-01-01",
-        elements: [
-          {
-            type: "channel",
-            channel: "push",
-            elements: [
-              { type: "text", content: "Push Title", text_style: "h2" },
-              { type: "text", content: "Push Body Text" },
-            ],
-          },
-        ],
-      });
+      expect(convertElementalToTiptap).toHaveBeenCalledWith(
+        {
+          version: "2022-01-01",
+          elements: [
+            {
+              type: "channel",
+              channel: "push",
+              elements: [
+                { type: "text", content: "Push Title", text_style: "h2" },
+                { type: "text", content: "Push Body Text" },
+              ],
+            },
+          ],
+        },
+        { renderEngine: undefined }
+      );
     });
   });
 

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Push/Push.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Push/Push.tsx
@@ -8,6 +8,7 @@ import {
   pendingAutoSaveAtom,
   getFormUpdating,
   previewLocaleAtom,
+  renderEngineAtom,
 } from "@/components/TemplateEditor/store";
 import type { TextMenuConfig } from "@/components/ui/TextMenu/config";
 import { selectedNodeAtom } from "@/components/ui/TextMenu/store";
@@ -36,6 +37,7 @@ export const PushEditorContent = ({ value }: { value?: TiptapDoc | null }) => {
   const { editor } = useCurrentEditor();
   const setTemplateEditor = useSetAtom(templateEditorAtom);
   const templateEditorContent = useAtomValue(templateEditorContentAtom);
+  const renderEngine = useAtomValue(renderEngineAtom);
   const isTemplateLoading = useAtomValue(isTemplateLoadingAtom);
   const isValueUpdated = useRef(false);
 
@@ -104,10 +106,13 @@ export const PushEditorContent = ({ value }: { value?: TiptapDoc | null }) => {
       elements: pushElements,
     };
 
-    const newContent = convertElementalToTiptap({
-      version: "2022-01-01",
-      elements: [elementalContent],
-    });
+    const newContent = convertElementalToTiptap(
+      {
+        version: "2022-01-01",
+        elements: [elementalContent],
+      },
+      { renderEngine }
+    );
 
     const incomingContent = convertTiptapToElemental(newContent);
     const currentContent = convertTiptapToElemental(editor.getJSON() as TiptapDoc);
@@ -122,7 +127,7 @@ export const PushEditorContent = ({ value }: { value?: TiptapDoc | null }) => {
         }
       }, 1);
     }
-  }, [editor, templateEditorContent]);
+  }, [editor, templateEditorContent, renderEngine]);
 
   return null;
 };
@@ -231,6 +236,7 @@ const PushComponent = forwardRef<HTMLDivElement, PushProps>(
     const isMountedRef = useRef(false);
     const setSelectedNode = useSetAtom(selectedNodeAtom);
     const [templateEditorContent, setTemplateEditorContent] = useAtom(templateEditorContentAtom);
+    const renderEngine = useAtomValue(renderEngineAtom);
     const setPendingAutoSave = useSetAtom(pendingAutoSaveAtom);
     const isTemplateTransitioning = useAtomValue(isTemplateTransitioningAtom);
 
@@ -396,9 +402,9 @@ const PushComponent = forwardRef<HTMLDivElement, PushProps>(
         elements: [elementalContent],
       };
 
-      return convertElementalToTiptap(elementalForConversion);
+      return convertElementalToTiptap(elementalForConversion, { renderEngine });
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isTemplateLoading, previewLocale]); // Only recompute when loading state or locale changes - value/templateEditorContent intentionally omitted to keep EditorProvider stable
+    }, [isTemplateLoading, previewLocale, renderEngine]); // Only recompute when loading state, locale, or engine changes - value/templateEditorContent intentionally omitted to keep EditorProvider stable
 
     return (
       <MainLayout

--- a/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.test.tsx
@@ -78,6 +78,7 @@ vi.mock("@/components/TemplateEditor/store", () => ({
   blockDefaultsAtom: "blockDefaultsAtom",
   variablesEnabledAtom: "variablesEnabledAtom",
   previewLocaleAtom: "previewLocaleAtom",
+  renderEngineAtom: "renderEngineAtom",
   getFormUpdating: () => false,
   setFormUpdating: () => {},
 }));
@@ -100,6 +101,9 @@ vi.mock("jotai", () => ({
   useAtomValue: vi.fn((atom: unknown) => {
     if (atom === "isTemplateLoadingAtom") {
       return false;
+    }
+    if (atom === "renderEngineAtom") {
+      return undefined;
     }
     return null;
   }),
@@ -427,16 +431,19 @@ describe("SMS Component", () => {
 
       render(<SMS {...defaultProps} value={smsContent} />);
 
-      expect(convertElementalToTiptap).toHaveBeenCalledWith({
-        version: "2022-01-01",
-        elements: [
-          {
-            type: "channel",
-            channel: "sms",
-            elements: [{ type: "text", content: "Hello SMS" }], // Converted from raw.text for display
-          },
-        ],
-      });
+      expect(convertElementalToTiptap).toHaveBeenCalledWith(
+        {
+          version: "2022-01-01",
+          elements: [
+            {
+              type: "channel",
+              channel: "sms",
+              elements: [{ type: "text", content: "Hello SMS" }], // Converted from raw.text for display
+            },
+          ],
+        },
+        { renderEngine: undefined }
+      );
     });
 
     it("should handle null templateEditorContent", () => {

--- a/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.tsx
@@ -7,6 +7,7 @@ import {
   pendingAutoSaveAtom,
   getFormUpdating,
   previewLocaleAtom,
+  renderEngineAtom,
 } from "@/components/TemplateEditor/store";
 // import { BubbleTextMenu } from "@/components/ui/TextMenu/BubbleTextMenu";
 import type { TextMenuConfig } from "@/components/ui/TextMenu/config";
@@ -66,6 +67,7 @@ export const SMSEditorContent = ({ value }: { value?: TiptapDoc | null }) => {
   const { editor } = useCurrentEditor();
   const setTemplateEditor = useSetAtom(templateEditorAtom);
   const templateEditorContent = useAtomValue(templateEditorContentAtom);
+  const renderEngine = useAtomValue(renderEngineAtom);
   const message = editor?.getText() ?? "";
   const segmentedMessage = useMemo(() => new SegmentedMessage(message), [message]);
   const isTemplateLoading = useAtomValue(isTemplateLoadingAtom);
@@ -124,10 +126,13 @@ export const SMSEditorContent = ({ value }: { value?: TiptapDoc | null }) => {
       elements: smsElements,
     };
 
-    const newContent = convertElementalToTiptap({
-      version: "2022-01-01",
-      elements: [elementalContent],
-    });
+    const newContent = convertElementalToTiptap(
+      {
+        version: "2022-01-01",
+        elements: [elementalContent],
+      },
+      { renderEngine }
+    );
 
     const incomingContent = convertTiptapToElemental(newContent);
     const currentContent = convertTiptapToElemental(editor.getJSON() as TiptapDoc);
@@ -142,7 +147,7 @@ export const SMSEditorContent = ({ value }: { value?: TiptapDoc | null }) => {
         }
       }, 1);
     }
-  }, [editor, templateEditorContent]);
+  }, [editor, templateEditorContent, renderEngine]);
 
   return (
     <span className="courier-self-end courier-pr-2 courier-text-xs courier-color-gray-500">
@@ -224,6 +229,7 @@ const SMSComponent = forwardRef<HTMLDivElement, SMSProps>(
     const isMountedRef = useRef(false);
     const setSelectedNode = useSetAtom(selectedNodeAtom);
     const [templateEditorContent, setTemplateEditorContent] = useAtom(templateEditorContentAtom);
+    const renderEngine = useAtomValue(renderEngineAtom);
     const setPendingAutoSave = useSetAtom(pendingAutoSaveAtom);
     const isTemplateTransitioning = useAtomValue(isTemplateTransitioningAtom);
 
@@ -336,9 +342,9 @@ const SMSComponent = forwardRef<HTMLDivElement, SMSProps>(
           ) as typeof elementalForConversion) ?? elementalForConversion;
       }
 
-      return convertElementalToTiptap(elementalForConversion);
+      return convertElementalToTiptap(elementalForConversion, { renderEngine });
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isTemplateLoading, previewLocale]); // Only recompute when loading state or locale changes - value/templateEditorContent intentionally omitted to keep EditorProvider stable
+    }, [isTemplateLoading, previewLocale, renderEngine]); // Only recompute when loading state, locale, or engine changes - value/templateEditorContent intentionally omitted to keep EditorProvider stable
 
     return (
       <MainLayout

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Slack/Slack.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Slack/Slack.test.tsx
@@ -81,6 +81,7 @@ vi.mock("@/components/TemplateEditor/store", () => ({
   visibleBlocksAtom: "visibleBlocksAtom",
   variablesEnabledAtom: "variablesEnabledAtom",
   previewLocaleAtom: "previewLocaleAtom",
+  renderEngineAtom: "renderEngineAtom",
   isPresetReference: () => false,
   getFormUpdating: () => false,
   setFormUpdating: () => {},
@@ -126,6 +127,9 @@ vi.mock("jotai", () => ({
     }
     if (atom === "visibleBlocksAtom") {
       return mockVisibleBlocks;
+    }
+    if (atom === "renderEngineAtom") {
+      return undefined;
     }
     return null;
   }),

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Slack/Slack.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Slack/Slack.tsx
@@ -10,6 +10,7 @@ import {
   isPresetReference,
   getFormUpdating,
   previewLocaleAtom,
+  renderEngineAtom,
   type VisibleBlockItem,
   type BlockElementType,
 } from "@/components/TemplateEditor/store";
@@ -77,6 +78,7 @@ export const SlackEditorContent = ({ value }: { value?: TiptapDoc }) => {
   const { editor } = useCurrentEditor();
   const setTemplateEditor = useSetAtom(templateEditorAtom);
   const templateEditorContent = useAtomValue(templateEditorContentAtom);
+  const renderEngine = useAtomValue(renderEngineAtom);
   const isTemplateLoading = useAtomValue(isTemplateLoadingAtom);
   const selectedNode = useAtomValue(selectedNodeAtom);
   const isValueUpdated = useRef(false);
@@ -142,7 +144,7 @@ export const SlackEditorContent = ({ value }: { value?: TiptapDoc }) => {
         version: "2022-01-01",
         elements: [element],
       },
-      { channel: "slack" }
+      { channel: "slack", renderEngine }
     );
 
     const incomingContent = convertTiptapToElemental(newContent);
@@ -158,7 +160,7 @@ export const SlackEditorContent = ({ value }: { value?: TiptapDoc }) => {
         }
       }, 1);
     }
-  }, [editor, templateEditorContent]);
+  }, [editor, templateEditorContent, renderEngine]);
 
   return null;
 };
@@ -359,6 +361,7 @@ const SlackComponent = forwardRef<HTMLDivElement, SlackProps>(
 
     const [selectedNode, setSelectedNode] = useAtom(selectedNodeAtom);
     const [templateEditorContent, setTemplateEditorContent] = useAtom(templateEditorContentAtom);
+    const renderEngine = useAtomValue(renderEngineAtom);
     const setPendingAutoSave = useSetAtom(pendingAutoSaveAtom);
 
     const previewLocale = useAtomValue(previewLocaleAtom);
@@ -579,8 +582,11 @@ const SlackComponent = forwardRef<HTMLDivElement, SlackProps>(
           ) as typeof elementalForConversion) ?? elementalForConversion;
       }
 
-      return convertElementalToTiptap(elementalForConversion, { channel: "slack" });
-    }, [value, previewLocale]);
+      return convertElementalToTiptap(elementalForConversion, {
+        channel: "slack",
+        renderEngine,
+      });
+    }, [value, previewLocale, renderEngine]);
 
     return (
       <MainLayout

--- a/packages/react-designer/src/components/TemplateEditor/Channels/architecture-consistency.test.ts
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/architecture-consistency.test.ts
@@ -64,8 +64,9 @@ describe("Architecture Consistency Tests", () => {
 
           if (useMemoMatch) {
             const deps = useMemoMatch[1].trim();
-            // Should depend on isTemplateLoading and optionally previewLocale
-            expect(deps).toMatch(/^isTemplateLoading(, previewLocale)?$/);
+            // Should depend on isTemplateLoading and optionally previewLocale and
+            // renderEngine (the latter so Liquid tag chips render on load).
+            expect(deps).toMatch(/^isTemplateLoading(, previewLocale)?(, renderEngine)?$/);
           }
         });
 
@@ -97,8 +98,9 @@ describe("Architecture Consistency Tests", () => {
 
         it("should NOT use useState for editorContent (old buggy pattern)", () => {
           // The old buggy pattern used useState for editorContent
-          const hasBuggyPattern =
-            fileContent.includes("const [editorContent, setEditorContent] = useState");
+          const hasBuggyPattern = fileContent.includes(
+            "const [editorContent, setEditorContent] = useState"
+          );
           expect(hasBuggyPattern).toBe(false);
         });
 
@@ -190,7 +192,7 @@ describe("Architecture Consistency Tests", () => {
       // All channels should have the same dependency pattern
       expect(patterns.length).toBe(3);
       expect(new Set(patterns).size).toBe(1); // All should be identical
-      expect(patterns[0]).toMatch(/^isTemplateLoading(, previewLocale)?$/);
+      expect(patterns[0]).toMatch(/^isTemplateLoading(, previewLocale)?(, renderEngine)?$/);
     });
 
     it("all fixed channels should NOT have the old buggy pattern", () => {

--- a/packages/react-designer/src/components/TemplateEditor/TemplateEditor.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/TemplateEditor.tsx
@@ -1,5 +1,5 @@
 import { useAutoSave } from "@/hooks/useAutoSave";
-import type { ElementalContent, ElementalNode } from "@/types/elemental.types";
+import type { ElementalContent, ElementalNode, RenderEngine } from "@/types/elemental.types";
 import type { VariableValidationConfig } from "@/types/validation.types";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import type { HTMLAttributes } from "react";
@@ -47,6 +47,8 @@ import {
   readOnlyAtom,
   sampleDataAtom,
   previewLocaleAtom,
+  renderEngineAtom,
+  DEFAULT_RENDER_ENGINE,
 } from "./store";
 
 export interface TemplateEditorProps
@@ -104,6 +106,21 @@ export interface TemplateEditorProps
    * to the displayed content. Does not modify the stored content.
    */
   locale?: string;
+  /**
+   * Controls the template's rendering engine, persisted to the content's
+   * `render_options.engine`. When provided, the editor is controlled: this
+   * value overrides whatever the loaded content specifies, and changing it
+   * persists the new engine. When omitted, the engine is read from the loaded
+   * content and defaults to Handlebars.
+   */
+  renderEngine?: RenderEngine;
+  /**
+   * Called with the effective rendering engine — when it's hydrated from the
+   * loaded template's `render_options` and whenever it changes. Lets a
+   * controlled consumer reflect the loaded template's engine (e.g. show the
+   * right value in an external selector) instead of forcing its own default.
+   */
+  onRenderEngineChange?: (engine: RenderEngine) => void;
 }
 
 // Helper function to resolve channels with priority: routing.channels > channels prop
@@ -143,6 +160,8 @@ const TemplateEditorComponent: React.FC<TemplateEditorProps> = ({
   readOnly = false,
   sampleData,
   locale,
+  renderEngine,
+  onRenderEngineChange,
   ...rest
 }) => {
   // const [__, setElementalValue] = useState<ElementalContent | undefined>(value);
@@ -178,6 +197,10 @@ const TemplateEditorComponent: React.FC<TemplateEditorProps> = ({
   }, [templateEditorContent]);
   const setBrandEditorContent = useSetAtom(BrandEditorContentAtom);
   const setBrandEditorForm = useSetAtom(BrandEditorFormAtom);
+  const setRenderEngine = useSetAtom(renderEngineAtom);
+  // Last `renderEngine` prop value reconciled to the atom. Initialized to the
+  // mount value so a change during the load window is still detected (and saved).
+  const renderEnginePropRef = useRef<RenderEngine | undefined>(renderEngine);
   const [channel, setChannel] = useAtom(channelAtom);
 
   // Expose API functions for E2E testing (after channel state is defined)
@@ -287,6 +310,10 @@ const TemplateEditorComponent: React.FC<TemplateEditorProps> = ({
       // Clear all content state
       setTemplateData(null);
       setTemplateEditorContent(null);
+      setRenderEngine(DEFAULT_RENDER_ENGINE);
+      // Re-seed to the current prop so the next template aligns the atom to the
+      // prop without an unsolicited save (a real toggle still differs and saves).
+      renderEnginePropRef.current = renderEngine;
       setBrandEditorContent(null);
       setBrandEditorForm(null);
       setSubject(null);
@@ -306,6 +333,8 @@ const TemplateEditorComponent: React.FC<TemplateEditorProps> = ({
     setIsTemplateTransitioning,
     setTemplateData,
     setTemplateEditorContent,
+    setRenderEngine,
+    renderEngine,
     setBrandEditorContent,
     setBrandEditorForm,
     setSubject,
@@ -495,6 +524,14 @@ const TemplateEditorComponent: React.FC<TemplateEditorProps> = ({
     // const content = templateData?.data?.tenant?.notification?.data?.content || value;
     const content = value || templateData?.data?.tenant?.notification?.data?.content;
     setTemplateEditorContent(content);
+    // Hydrate the rendering engine from the loaded content's render_options.
+    // Skip when controlled via the `renderEngine` prop so the prop wins.
+    if (renderEngine === undefined) {
+      const hydratedEngine = content?.render_options?.engine ?? DEFAULT_RENDER_ENGINE;
+      setRenderEngine(hydratedEngine);
+      // Report the loaded engine so an external selector can reflect it.
+      onRenderEngineChange?.(hydratedEngine);
+    }
     lastSyncedTemplateDataRef.current = templateData; // Mark this templateData as synced
 
     // End transition when new template data is loaded
@@ -504,6 +541,9 @@ const TemplateEditorComponent: React.FC<TemplateEditorProps> = ({
   }, [
     templateData,
     setTemplateEditorContent,
+    setRenderEngine,
+    renderEngine,
+    onRenderEngineChange,
     isTemplateLoading,
     setIsTemplateTransitioning,
     templateId,
@@ -515,6 +555,35 @@ const TemplateEditorComponent: React.FC<TemplateEditorProps> = ({
       isResponseSetRef.current = false;
     }
   }, [isTemplatePublishing]);
+
+  // Sync the controlled `renderEngine` prop into the atom. `renderEnginePropRef`
+  // tracks the last prop value reconciled (mount value; re-seeded on template
+  // switch) so we only act on real changes. We persist only when the prop
+  // differs from what the loaded content already declares — so reflecting the
+  // loaded engine back (via onRenderEngineChange) never triggers an unsolicited
+  // save, while a genuine user switch does.
+  useEffect(() => {
+    if (renderEngine === undefined || isTemplateLoading !== false) {
+      return;
+    }
+    if (renderEnginePropRef.current === renderEngine) {
+      setRenderEngine(renderEngine);
+      return;
+    }
+    renderEnginePropRef.current = renderEngine;
+    setRenderEngine(renderEngine);
+    const loadedEngine = templateEditorContent?.render_options?.engine ?? DEFAULT_RENDER_ENGINE;
+    if (renderEngine !== loadedEngine && !readOnly) {
+      void saveTemplate();
+    }
+  }, [
+    renderEngine,
+    isTemplateLoading,
+    readOnly,
+    setRenderEngine,
+    saveTemplate,
+    templateEditorContent,
+  ]);
 
   useEffect(() => {
     if (!templateEditorContent || isTemplateLoading !== false) {

--- a/packages/react-designer/src/components/TemplateEditor/VariableViewModeSync.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/VariableViewModeSync.tsx
@@ -1,7 +1,7 @@
 import { useCurrentEditor } from "@tiptap/react";
 import { useAtomValue } from "jotai";
 import { useEffect, useRef } from "react";
-import { type VariableViewMode, variablesEnabledAtom } from "./store";
+import { renderEngineAtom, type VariableViewMode, variablesEnabledAtom } from "./store";
 import {
   setVariableViewMode,
   getVariableViewMode,
@@ -24,6 +24,7 @@ export const VariableViewModeSync = ({ variableViewMode }: VariableViewModeSyncP
   const { editor } = useCurrentEditor();
   const lastVariableViewModeRef = useRef<VariableViewMode | null>(null);
   const variablesEnabled = useAtomValue(variablesEnabledAtom);
+  const renderEngine = useAtomValue(renderEngineAtom);
 
   useEffect(() => {
     if (editor && lastVariableViewModeRef.current !== variableViewMode) {
@@ -43,6 +44,13 @@ export const VariableViewModeSync = ({ variableViewMode }: VariableViewModeSyncP
       editor.storage.variableInputRule.disabled = !variablesEnabled;
     }
   }, [editor, variablesEnabled]);
+
+  // Enable the `{%` Liquid-tag input rule only when the engine is Liquid.
+  useEffect(() => {
+    if (editor?.storage?.liquidTagInputRule) {
+      editor.storage.liquidTagInputRule.disabled = renderEngine !== "liquid";
+    }
+  }, [editor, renderEngine]);
 
   return null;
 };

--- a/packages/react-designer/src/components/TemplateEditor/store.ts
+++ b/packages/react-designer/src/components/TemplateEditor/store.ts
@@ -1,10 +1,20 @@
 import { atom } from "jotai";
-import type { ElementalContent } from "@/types/elemental.types";
+import type { ElementalContent, RenderEngine } from "@/types/elemental.types";
 import type { VariableValidationConfig } from "@/types/validation.types";
 import type { Editor } from "@tiptap/react";
 import { EMAIL_EDITOR_FONT_FAMILY } from "@/lib/constants/email-editor-tiptap-styles";
 
 export const subjectAtom = atom<string | null>(null);
+
+/** Default rendering engine when a template has no `render_options.engine`. */
+export const DEFAULT_RENDER_ENGINE: RenderEngine = "handlebars";
+
+/**
+ * Source of truth for the template's rendering engine. Hydrated from the
+ * loaded content's `render_options.engine` and injected back into the content
+ * at save time. Defaults to Handlebars.
+ */
+export const renderEngineAtom = atom<RenderEngine>(DEFAULT_RENDER_ENGINE);
 
 export const EMAIL_DEFAULT_BACKGROUND_COLOR = "#FAF8F6";
 export const EMAIL_DEFAULT_CONTENT_BODY_COLOR = "#ffffff";

--- a/packages/react-designer/src/components/extensions/LiquidTag/LiquidTag.test.ts
+++ b/packages/react-designer/src/components/extensions/LiquidTag/LiquidTag.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { NodeSelection } from "prosemirror-state";
+import { LiquidTagNode, LiquidTagInputRule } from "./LiquidTag";
+import { VARIABLE_ENTER_EDIT_META } from "../Variable/Variable.types";
+
+vi.mock("@tiptap/react", () => ({
+  ReactNodeViewRenderer: vi.fn(() => "MockedReactNodeViewRenderer"),
+}));
+
+vi.mock("./LiquidTagView", () => ({
+  LiquidTagView: vi.fn(() => "MockedLiquidTagView"),
+}));
+
+describe("LiquidTagNode", () => {
+  it("is an inline atom named liquidTag", () => {
+    expect(LiquidTagNode.name).toBe("liquidTag");
+    expect(LiquidTagNode.config.group).toBe("inline");
+    expect(LiquidTagNode.config.inline).toBe(true);
+    expect(LiquidTagNode.config.atom).toBe(true);
+  });
+
+  it("has elevated priority so Enter-to-edit beats Paragraph", () => {
+    expect(LiquidTagNode.config.priority).toBe(1001);
+  });
+
+  describe("Enter-to-edit shortcut", () => {
+    function invokeEnter(editor: unknown) {
+      const shortcuts = (
+        LiquidTagNode.config.addKeyboardShortcuts as (this: { editor: unknown; name: string }) => {
+          Enter: () => boolean;
+        }
+      ).call({ editor, name: "liquidTag" });
+      return shortcuts.Enter();
+    }
+
+    function makeTagSelection(from: number) {
+      const selection = Object.create(NodeSelection.prototype);
+      Object.defineProperty(selection, "node", {
+        value: { type: { name: "liquidTag" } },
+        configurable: true,
+      });
+      Object.defineProperty(selection, "from", { value: from, configurable: true });
+      return selection;
+    }
+
+    it("requests edit mode when a tag node is selected", () => {
+      const dispatch = vi.fn();
+      const setMeta = vi.fn(() => ({ marked: true }));
+      const editor = {
+        isEditable: true,
+        state: { selection: makeTagSelection(7), tr: { setMeta } },
+        view: { dispatch },
+      };
+
+      expect(invokeEnter(editor)).toBe(true);
+      expect(setMeta).toHaveBeenCalledWith(VARIABLE_ENTER_EDIT_META, 7);
+      expect(dispatch).toHaveBeenCalledWith({ marked: true });
+    });
+
+    it("ignores Enter for a non-tag selection", () => {
+      const editor = {
+        isEditable: true,
+        state: { selection: { from: 1 }, tr: { setMeta: vi.fn() } },
+        view: { dispatch: vi.fn() },
+      };
+      expect(invokeEnter(editor)).toBe(false);
+    });
+  });
+
+  it("input rule is disabled by default (enabled only under Liquid)", () => {
+    expect(LiquidTagInputRule.name).toBe("liquidTagInputRule");
+    expect(LiquidTagInputRule.storage).toEqual({ disabled: true });
+  });
+});

--- a/packages/react-designer/src/components/extensions/LiquidTag/LiquidTag.ts
+++ b/packages/react-designer/src/components/extensions/LiquidTag/LiquidTag.ts
@@ -1,0 +1,113 @@
+import { Extension, InputRule, Node } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import { NodeSelection } from "prosemirror-state";
+import { VARIABLE_ENTER_EDIT_META } from "../Variable/Variable.types";
+import { LiquidTagView } from "./LiquidTagView";
+
+export interface LiquidTagNodeOptions {
+  HTMLAttributes?: Record<string, unknown>;
+}
+
+/**
+ * Inline atom node for Liquid `{% ... %}` control-flow tags (if/for/assign/…).
+ * The tag is stored verbatim as text on save; this node only gives it a distinct
+ * visual chip in the editor. There is no validation — Liquid runs per field, so
+ * structural correctness is the author's responsibility (and the renderer's).
+ */
+export const LiquidTagNode = Node.create<LiquidTagNodeOptions>({
+  name: "liquidTag",
+  group: "inline",
+  inline: true,
+  selectable: true,
+  atom: true,
+  // Above Paragraph (default 100) so Enter-to-edit beats the line-break handler,
+  // matching the variable chip.
+  priority: 1001,
+
+  addAttributes() {
+    return {
+      content: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-content") || "",
+        renderHTML: (attributes) => ({ "data-content": attributes.content }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "span[data-liquid-tag]",
+        getAttrs: (element) => {
+          const content = (element as HTMLElement).getAttribute("data-content");
+          return content !== null ? { content } : false;
+        },
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes, node }) {
+    return [
+      "span",
+      { "data-liquid-tag": "true", ...HTMLAttributes },
+      `{% ${node.attrs.content} %}`,
+    ];
+  },
+
+  renderText({ node }) {
+    return `{% ${node.attrs.content} %}`;
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(LiquidTagView);
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      // Enter on a selected tag chip drops into edit mode (see VariableNode).
+      Enter: () => {
+        const { selection } = this.editor.state;
+        if (
+          this.editor.isEditable &&
+          selection instanceof NodeSelection &&
+          selection.node.type.name === this.name
+        ) {
+          const tr = this.editor.state.tr.setMeta(VARIABLE_ENTER_EDIT_META, selection.from);
+          this.editor.view.dispatch(tr);
+          return true;
+        }
+        return false;
+      },
+    };
+  },
+});
+
+/**
+ * Turns a typed `{%` into a Liquid tag chip. Disabled by default; enabled only
+ * when the render engine is Liquid (synced from `VariableViewModeSync`).
+ */
+export const LiquidTagInputRule = Extension.create({
+  name: "liquidTagInputRule",
+
+  addStorage() {
+    return {
+      disabled: true,
+    };
+  },
+
+  addInputRules() {
+    const storage = this.storage;
+    return [
+      new InputRule({
+        find: /\{%$/,
+        handler: ({ range, chain }) => {
+          if (storage.disabled) return;
+          chain()
+            .deleteRange(range)
+            .insertContent([{ type: "liquidTag", attrs: { content: "" } }])
+            .run();
+        },
+      }),
+    ];
+  },
+});

--- a/packages/react-designer/src/components/extensions/LiquidTag/LiquidTagIcon.tsx
+++ b/packages/react-designer/src/components/extensions/LiquidTag/LiquidTagIcon.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+interface LiquidTagIconProps {
+  color?: string;
+}
+
+/** Percent glyph evoking Liquid's `{% %}` control-flow syntax. */
+export const LiquidTagIcon: React.FC<LiquidTagIconProps> = ({ color = "#0369A1" }) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className="courier-flex-shrink-0"
+  >
+    <line
+      x1="12"
+      y1="3.5"
+      x2="4"
+      y2="12.5"
+      stroke={color}
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <circle cx="4.75" cy="4.75" r="1.75" stroke={color} strokeWidth="1.5" />
+    <circle cx="11.25" cy="11.25" r="1.75" stroke={color} strokeWidth="1.5" />
+  </svg>
+);

--- a/packages/react-designer/src/components/extensions/LiquidTag/LiquidTagView.tsx
+++ b/packages/react-designer/src/components/extensions/LiquidTag/LiquidTagView.tsx
@@ -1,0 +1,141 @@
+import type { NodeViewProps } from "@tiptap/core";
+import { NodeViewWrapper } from "@tiptap/react";
+import { NodeSelection, TextSelection } from "prosemirror-state";
+import React, { useCallback, useEffect, useState } from "react";
+import { VariableChipBase } from "../../ui/VariableEditor/VariableChipBase";
+import { VARIABLE_ENTER_EDIT_META } from "../Variable/Variable.types";
+import { LiquidTagIcon } from "./LiquidTagIcon";
+
+/** Liquid tags can be longer than variable names (e.g. `for x in data.items`). */
+const LIQUID_TAG_MAX_LENGTH = 200;
+
+export const LiquidTagView: React.FC<NodeViewProps> = ({
+  node,
+  editor,
+  getPos,
+  updateAttributes,
+}) => {
+  const content = node.attrs.content || "";
+  const [isWithinSelection, setIsWithinSelection] = useState(false);
+  // Bumped to request edit mode (e.g. Enter pressed on the selected chip).
+  const [editTrigger, setEditTrigger] = useState(0);
+
+  const checkSelection = useCallback(() => {
+    if (typeof getPos !== "function") return;
+    try {
+      const pos = getPos();
+      if (typeof pos !== "number") {
+        setIsWithinSelection(false);
+        return;
+      }
+      const { from, to, empty } = editor.state.selection;
+      setIsWithinSelection(!empty && from < pos + node.nodeSize && to > pos);
+    } catch {
+      setIsWithinSelection(false);
+    }
+  }, [editor, getPos, node.nodeSize]);
+
+  useEffect(() => {
+    checkSelection();
+    // selectionUpdate covers chip selection state; no need for the update event.
+    editor.on("selectionUpdate", checkSelection);
+    return () => {
+      editor.off("selectionUpdate", checkSelection);
+    };
+  }, [editor, checkSelection]);
+
+  useEffect(() => {
+    const handleTransaction = ({
+      transaction,
+    }: {
+      transaction: { getMeta: (key: string) => unknown };
+    }) => {
+      const editPos = transaction.getMeta(VARIABLE_ENTER_EDIT_META);
+      if (typeof editPos === "number" && typeof getPos === "function" && getPos() === editPos) {
+        setEditTrigger((n) => n + 1);
+      }
+    };
+
+    editor.on("transaction", handleTransaction);
+    return () => {
+      editor.off("transaction", handleTransaction);
+    };
+  }, [editor, getPos]);
+
+  // The chip works in terms of a string `id`; map it to the tag `content` attr.
+  const handleUpdateAttributes = useCallback(
+    (attrs: { id: string }) => {
+      updateAttributes({ content: attrs.id });
+    },
+    [updateAttributes]
+  );
+
+  const handleDelete = useCallback(() => {
+    if (typeof getPos === "function") {
+      const pos = getPos();
+      if (typeof pos === "number") {
+        editor
+          .chain()
+          .focus()
+          .deleteRange({ from: pos, to: pos + node.nodeSize })
+          .run();
+      }
+    }
+  }, [editor, getPos, node.nodeSize]);
+
+  const handleSelect = useCallback(() => {
+    if (typeof getPos === "function") {
+      const pos = getPos();
+      if (typeof pos === "number") {
+        editor
+          .chain()
+          .focus()
+          .command(({ tr }) => {
+            tr.setSelection(NodeSelection.create(tr.doc, pos));
+            return true;
+          })
+          .run();
+      }
+    }
+  }, [editor, getPos]);
+
+  const handleCommit = useCallback(() => {
+    if (typeof getPos === "function") {
+      const pos = getPos();
+      if (typeof pos === "number") {
+        const afterPos = pos + node.nodeSize;
+        requestAnimationFrame(() => {
+          if (editor.isDestroyed || !editor.state || !editor.view) return;
+          try {
+            const { tr } = editor.state;
+            tr.setSelection(TextSelection.create(tr.doc, afterPos));
+            editor.view.dispatch(tr);
+            editor.view.focus();
+          } catch {
+            // Editor may have been destroyed between scheduling and execution
+          }
+        });
+      }
+    }
+  }, [editor, getPos, node.nodeSize]);
+
+  return (
+    <NodeViewWrapper as="span" className="courier-inline courier-max-w-full">
+      <VariableChipBase
+        variableId={content}
+        isInvalid={false}
+        onUpdateAttributes={handleUpdateAttributes}
+        onDelete={handleDelete}
+        icon={<LiquidTagIcon />}
+        className="courier-liquid-tag-chip"
+        readOnly={!editor.isEditable}
+        isSelected={isWithinSelection}
+        onSelect={handleSelect}
+        onCommit={handleCommit}
+        editTrigger={editTrigger}
+        freeform
+        maxLength={LIQUID_TAG_MAX_LENGTH}
+      />
+    </NodeViewWrapper>
+  );
+};

--- a/packages/react-designer/src/components/extensions/LiquidTag/index.ts
+++ b/packages/react-designer/src/components/extensions/LiquidTag/index.ts
@@ -1,0 +1,4 @@
+export { LiquidTagNode, LiquidTagInputRule } from "./LiquidTag";
+export type { LiquidTagNodeOptions } from "./LiquidTag";
+export { LiquidTagView } from "./LiquidTagView";
+export { LiquidTagIcon } from "./LiquidTagIcon";

--- a/packages/react-designer/src/components/extensions/Variable/Variable.test.tsx
+++ b/packages/react-designer/src/components/extensions/Variable/Variable.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NodeSelection } from "prosemirror-state";
 import { VariableNode, VariableInputRule } from "./Variable";
-import type { VariableNodeOptions } from "./Variable.types";
+import { VARIABLE_ENTER_EDIT_META, type VariableNodeOptions } from "./Variable.types";
 
 // Mock TipTap modules
 vi.mock("@tiptap/react", () => ({
@@ -359,6 +360,70 @@ describe("Variable Cursor Navigation Fix", () => {
       const configured = VariableNode.configure({});
       expect(configured).toBeDefined();
       expect(configured.name).toBe("variable");
+    });
+  });
+
+  describe("Enter-to-edit shortcut", () => {
+    // Must outrank Paragraph (default priority 100), whose Enter handler would
+    // otherwise replace the selected chip with a line break.
+    it("has elevated priority so it intercepts Enter first", () => {
+      expect(VariableNode.config.priority).toBe(1001);
+    });
+
+    function invokeEnter(editor: unknown) {
+      const shortcuts = (
+        VariableNode.config.addKeyboardShortcuts as (this: { editor: unknown; name: string }) => {
+          Enter: () => boolean;
+        }
+      ).call({ editor, name: "variable" });
+      return shortcuts.Enter();
+    }
+
+    function makeVariableNodeSelection(from: number) {
+      // `from`/`node` are getters on the prototype; shadow them on the instance.
+      const selection = Object.create(NodeSelection.prototype);
+      Object.defineProperty(selection, "node", {
+        value: { type: { name: "variable" } },
+        configurable: true,
+      });
+      Object.defineProperty(selection, "from", { value: from, configurable: true });
+      return selection;
+    }
+
+    it("requests edit mode when a variable node is selected", () => {
+      const dispatch = vi.fn();
+      const setMeta = vi.fn(() => ({ marked: true }));
+      const selection = makeVariableNodeSelection(5);
+      const editor = {
+        isEditable: true,
+        state: { selection, tr: { setMeta } },
+        view: { dispatch },
+      };
+
+      expect(invokeEnter(editor)).toBe(true);
+      expect(setMeta).toHaveBeenCalledWith(VARIABLE_ENTER_EDIT_META, 5);
+      expect(dispatch).toHaveBeenCalledWith({ marked: true });
+    });
+
+    it("ignores Enter when the selection is not a variable NodeSelection", () => {
+      const editor = {
+        isEditable: true,
+        state: { selection: { from: 1 }, tr: { setMeta: vi.fn() } },
+        view: { dispatch: vi.fn() },
+      };
+
+      expect(invokeEnter(editor)).toBe(false);
+    });
+
+    it("ignores Enter when the editor is not editable", () => {
+      const selection = makeVariableNodeSelection(5);
+      const editor = {
+        isEditable: false,
+        state: { selection, tr: { setMeta: vi.fn() } },
+        view: { dispatch: vi.fn() },
+      };
+
+      expect(invokeEnter(editor)).toBe(false);
     });
   });
 });

--- a/packages/react-designer/src/components/extensions/Variable/Variable.ts
+++ b/packages/react-designer/src/components/extensions/Variable/Variable.ts
@@ -1,10 +1,14 @@
 import { Extension, InputRule, Node } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { Suggestion } from "@tiptap/suggestion";
-import { Plugin, PluginKey, TextSelection } from "prosemirror-state";
+import { NodeSelection, Plugin, PluginKey, TextSelection } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import { suggestion } from "./suggestion";
-import type { VariableNodeOptions, VariableOptions } from "./Variable.types";
+import {
+  VARIABLE_ENTER_EDIT_META,
+  type VariableNodeOptions,
+  type VariableOptions,
+} from "./Variable.types";
 import { VariableView } from "./VariableView";
 import { initializeVariableStorage } from "./variable-storage.utils";
 
@@ -14,6 +18,9 @@ export const VariableNode = Node.create<VariableNodeOptions>({
   inline: true,
   selectable: true,
   atom: true,
+  // Above Paragraph (default 100) so the Enter-to-edit shortcut intercepts a
+  // selected chip before Paragraph's Enter replaces it with a line break.
+  priority: 1001,
 
   addStorage() {
     return initializeVariableStorage();
@@ -72,6 +79,26 @@ export const VariableNode = Node.create<VariableNodeOptions>({
 
   addNodeView() {
     return ReactNodeViewRenderer(VariableView);
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      // When a variable chip is selected (NodeSelection), Enter drops into edit
+      // mode instead of splitting the block. The NodeView listens for this meta.
+      Enter: () => {
+        const { selection } = this.editor.state;
+        if (
+          this.editor.isEditable &&
+          selection instanceof NodeSelection &&
+          selection.node.type.name === this.name
+        ) {
+          const tr = this.editor.state.tr.setMeta(VARIABLE_ENTER_EDIT_META, selection.from);
+          this.editor.view.dispatch(tr);
+          return true;
+        }
+        return false;
+      },
+    };
   },
 
   addProseMirrorPlugins() {

--- a/packages/react-designer/src/components/extensions/Variable/Variable.types.ts
+++ b/packages/react-designer/src/components/extensions/Variable/Variable.types.ts
@@ -1,6 +1,13 @@
 import type { Editor, Range } from "@tiptap/core";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 
+/**
+ * Transaction meta key used to ask a selected variable's NodeView to enter edit
+ * mode (e.g. when the user presses Enter on a selected chip). The value is the
+ * document position of the variable node.
+ */
+export const VARIABLE_ENTER_EDIT_META = "variableEnterEditPos";
+
 export interface VariableNodeOptions {
   HTMLAttributes?: Record<string, unknown>;
 }

--- a/packages/react-designer/src/components/extensions/Variable/VariableView.tsx
+++ b/packages/react-designer/src/components/extensions/Variable/VariableView.tsx
@@ -6,6 +6,7 @@ import { NodeSelection, TextSelection } from "prosemirror-state";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { variableValuesAtom, type VariableViewMode } from "../../TemplateEditor/store";
 import { VariableChipBase } from "../../ui/VariableEditor/VariableChipBase";
+import { VARIABLE_ENTER_EDIT_META } from "./Variable.types";
 import { VariableIcon } from "./VariableIcon";
 import { getVariableViewMode } from "./variable-storage.utils";
 
@@ -58,6 +59,8 @@ export const VariableView: React.FC<NodeViewProps> = ({
   const [isInButton, setIsInButton] = useState(false);
   const [isInsideLoop, setIsInsideLoop] = useState(false);
   const [isWithinSelection, setIsWithinSelection] = useState(false);
+  // Bumped to request edit mode (e.g. Enter pressed on the selected chip).
+  const [editTrigger, setEditTrigger] = useState(0);
 
   const formattingStyle = useMemo(() => getFormattingStyleFromMarks(node.marks), [node]);
 
@@ -69,11 +72,18 @@ export const VariableView: React.FC<NodeViewProps> = ({
     const handleTransaction = ({
       transaction,
     }: {
-      transaction: { getMeta: (key: string) => boolean | undefined };
+      transaction: { getMeta: (key: string) => unknown };
     }) => {
       if (transaction.getMeta("variableViewModeChanged")) {
         const newMode = getVariableViewMode(editor);
         setVariableViewMode(newMode);
+      }
+
+      // Enter pressed on the selected chip → ask this NodeView to edit, but only
+      // if the requested position matches this node.
+      const editPos = transaction.getMeta(VARIABLE_ENTER_EDIT_META);
+      if (typeof editPos === "number" && typeof getPos === "function" && getPos() === editPos) {
+        setEditTrigger((n) => n + 1);
       }
     };
 
@@ -81,7 +91,7 @@ export const VariableView: React.FC<NodeViewProps> = ({
     return () => {
       editor.off("transaction", handleTransaction);
     };
-  }, [editor, variableId]);
+  }, [editor, variableId, getPos]);
 
   useEffect(() => {
     const currentMode = getVariableViewMode(editor);
@@ -268,6 +278,7 @@ export const VariableView: React.FC<NodeViewProps> = ({
         onSelect={handleSelect}
         onCommit={handleCommit}
         isInsideLoop={isInsideLoop}
+        editTrigger={editTrigger}
       />
     </NodeViewWrapper>
   );

--- a/packages/react-designer/src/components/extensions/extension-kit.ts
+++ b/packages/react-designer/src/components/extensions/extension-kit.ts
@@ -36,6 +36,8 @@ import {
   VariableInputRule,
   VariableNode,
   VariablePaste,
+  LiquidTagNode,
+  LiquidTagInputRule,
 } from ".";
 
 export interface RichTextMarksConfig {
@@ -195,6 +197,9 @@ export const ExtensionKit = (options?: ExtensionKitOptions) => {
     // Always use VariableInputRule to create chips - autocomplete is shown inside the chip
     VariableInputRule,
     VariablePaste,
+    LiquidTagNode,
+    // Disabled unless the render engine is Liquid (see VariableViewModeSync)
+    LiquidTagInputRule,
     FixedChannelPaste,
     FixedChannelSelection,
   ];

--- a/packages/react-designer/src/components/extensions/index.ts
+++ b/packages/react-designer/src/components/extensions/index.ts
@@ -37,3 +37,4 @@ export {
   Variable,
   VariableTypeHandler,
 } from "./Variable";
+export { LiquidTagNode, LiquidTagInputRule } from "./LiquidTag";

--- a/packages/react-designer/src/components/ui/VariableEditor/VariableChipBase.test.tsx
+++ b/packages/react-designer/src/components/ui/VariableEditor/VariableChipBase.test.tsx
@@ -2,10 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { VariableChipBase } from "./VariableChipBase";
 import { Provider, createStore } from "jotai";
-import {
-  variableValidationAtom,
-  availableVariablesAtom,
-} from "@/components/TemplateEditor/store";
+import { variableValidationAtom, availableVariablesAtom } from "@/components/TemplateEditor/store";
 import type { VariableValidationConfig } from "@/types/validation.types";
 import React from "react";
 
@@ -21,10 +18,7 @@ vi.mock("sonner", () => ({
 }));
 
 // Helper to create a store with validation config
-function createTestStore(
-  config?: VariableValidationConfig,
-  variables?: Record<string, unknown>
-) {
+function createTestStore(config?: VariableValidationConfig, variables?: Record<string, unknown>) {
   const store = createStore();
   store.set(variableValidationAtom, config);
   if (variables) {
@@ -292,9 +286,7 @@ describe("VariableChipBase", () => {
       fireEvent.blur(editableSpan);
 
       await waitFor(() => {
-        expect(mockToastError).toHaveBeenCalledWith(
-          '"custom.var" is not in the allowed list'
-        );
+        expect(mockToastError).toHaveBeenCalledWith('"custom.var" is not in the allowed list');
       });
     });
 
@@ -393,10 +385,7 @@ describe("VariableChipBase", () => {
     it("should apply bold formatting style to text span", () => {
       render(
         <TestWrapper>
-          <VariableChipBase
-            {...defaultProps}
-            formattingStyle={{ fontWeight: "bold" }}
-          />
+          <VariableChipBase {...defaultProps} formattingStyle={{ fontWeight: "bold" }} />
         </TestWrapper>
       );
 
@@ -407,10 +396,7 @@ describe("VariableChipBase", () => {
     it("should apply italic formatting style to text span", () => {
       render(
         <TestWrapper>
-          <VariableChipBase
-            {...defaultProps}
-            formattingStyle={{ fontStyle: "italic" }}
-          />
+          <VariableChipBase {...defaultProps} formattingStyle={{ fontStyle: "italic" }} />
         </TestWrapper>
       );
 
@@ -725,5 +711,47 @@ describe("VariableChipBase", () => {
       });
     });
   });
-});
 
+  describe("editTrigger (external edit request)", () => {
+    it("enters edit mode when editTrigger increments", async () => {
+      const store = createStore();
+      const { rerender } = render(
+        <Provider store={store}>
+          <VariableChipBase {...defaultProps} editTrigger={0} />
+        </Provider>
+      );
+
+      expect(screen.getByRole("textbox")).toHaveAttribute("contenteditable", "false");
+
+      rerender(
+        <Provider store={store}>
+          <VariableChipBase {...defaultProps} editTrigger={1} />
+        </Provider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("textbox")).toHaveAttribute("contenteditable", "true");
+      });
+    });
+
+    it("does not enter edit mode when readOnly", async () => {
+      const store = createStore();
+      const { rerender } = render(
+        <Provider store={store}>
+          <VariableChipBase {...defaultProps} readOnly editTrigger={0} />
+        </Provider>
+      );
+
+      rerender(
+        <Provider store={store}>
+          <VariableChipBase {...defaultProps} readOnly editTrigger={1} />
+        </Provider>
+      );
+
+      // Allow effects to flush, then confirm it stayed in display mode.
+      await waitFor(() => {
+        expect(screen.getByRole("textbox")).toHaveAttribute("contenteditable", "false");
+      });
+    });
+  });
+});

--- a/packages/react-designer/src/components/ui/VariableEditor/VariableChipBase.tsx
+++ b/packages/react-designer/src/components/ui/VariableEditor/VariableChipBase.tsx
@@ -1,6 +1,7 @@
 import {
   availableVariablesAtom,
   disableVariablesAutocompleteAtom,
+  renderEngineAtom,
   variableValidationAtom,
 } from "@/components/TemplateEditor/store";
 import { cn } from "@/lib";
@@ -9,10 +10,12 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { getFlattenedVariables } from "../../utils/getFlattenedVariables";
-import { isValidVariableName } from "../../utils/validateVariableName";
+import { ensureLiquidNamespace, isValidVariableName } from "../../utils/validateVariableName";
 import { VariableAutocomplete } from "./VariableAutocomplete";
 
 export const MAX_VARIABLE_LENGTH = 50;
+/** Liquid variable expressions (with filters/brackets) need more room than a name. */
+export const LIQUID_VARIABLE_MAX_LENGTH = 200;
 export const MAX_DISPLAY_LENGTH = 24;
 
 export interface VariableColors {
@@ -55,6 +58,19 @@ export interface VariableChipBaseProps {
   onCommit?: () => void;
   /** Whether this variable chip is inside a list node with a loop configured */
   isInsideLoop?: boolean;
+  /**
+   * Monotonically increasing token. Each increment requests that the chip enter
+   * edit mode (e.g. when Enter is pressed on the selected chip).
+   */
+  editTrigger?: number;
+  /**
+   * Free-form mode: the chip holds arbitrary text (e.g. a Liquid `{% %}` tag)
+   * with no autocomplete and no validation. The content is always treated as
+   * valid and may contain spaces.
+   */
+  freeform?: boolean;
+  /** Max characters for the editable content. Defaults to {@link MAX_VARIABLE_LENGTH}. */
+  maxLength?: number;
 }
 
 export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
@@ -74,6 +90,9 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
   onSelect,
   onCommit,
   isInsideLoop = false,
+  editTrigger,
+  freeform = false,
+  maxLength,
 }) => {
   void _getColors; // Colors handled by CSS, prop kept for API compatibility
   const [isEditing, setIsEditing] = useState(false);
@@ -84,9 +103,19 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
   const variableValidation = useAtomValue(variableValidationAtom);
   const availableVariables = useAtomValue(availableVariablesAtom);
   const disableAutocomplete = useAtomValue(disableVariablesAutocompleteAtom);
+  const renderEngine = useAtomValue(renderEngineAtom);
+  const isLiquid = renderEngine === "liquid";
+  // Liquid expressions (filters/brackets) run long, so allow more than a plain
+  // Handlebars variable name unless the caller pins an explicit limit.
+  const maxLen = maxLength ?? (isLiquid ? LIQUID_VARIABLE_MAX_LENGTH : MAX_VARIABLE_LENGTH);
 
   // Get flattened list of variable suggestions
   const allSuggestions = useMemo(() => {
+    // Free-form chips (e.g. Liquid tags) have no autocomplete.
+    if (freeform) {
+      return [];
+    }
+
     const loopVars = isInsideLoop ? ["$.item", "$.index"] : [];
 
     if (
@@ -96,8 +125,11 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
     ) {
       return loopVars;
     }
-    return [...loopVars, ...getFlattenedVariables(availableVariables)];
-  }, [availableVariables, disableAutocomplete, isInsideLoop]);
+    const flattened = getFlattenedVariables(availableVariables);
+    // Under Liquid, surface (and insert) variables under the `data.` namespace.
+    const vars = isLiquid ? flattened.map(ensureLiquidNamespace) : flattened;
+    return [...loopVars, ...vars];
+  }, [availableVariables, disableAutocomplete, isInsideLoop, isLiquid, freeform]);
 
   // Filter suggestions based on current query
   const filteredSuggestions = useMemo(() => {
@@ -120,15 +152,35 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
     }
   }, [variableId, isEditing, readOnly]);
 
+  // Enter edit mode when an external edit is requested (e.g. Enter on the
+  // selected chip). Only react to changes in the token, not to readOnly/isEditing.
+  const lastEditTriggerRef = useRef(editTrigger);
+  useEffect(() => {
+    if (editTrigger === undefined || editTrigger === lastEditTriggerRef.current) return;
+    lastEditTriggerRef.current = editTrigger;
+    if (!readOnly && !isEditing) {
+      setIsEditing(true);
+      setQuery("");
+      setSelectedIndex(0);
+    }
+  }, [editTrigger, readOnly, isEditing]);
+
   // Validate variable against custom validator or available list on mount/change
   useEffect(() => {
-    if (!variableId || isEditing) return;
+    // Free-form chips are never marked invalid.
+    if (freeform || !variableId || isEditing) return;
 
     let isValid = true;
     const context = { isInsideLoop };
 
     if (variableValidation?.validate) {
       isValid = variableValidation.validate(variableId, context);
+    } else if (isLiquid) {
+      // Liquid: validate by format/namespace (filters & brackets won't be
+      // literal list members), not by suggestion-list membership.
+      isValid =
+        isValidVariableName(variableId, "liquid") ||
+        (isInsideLoop && variableId.startsWith("$.item.") && variableId.length > 7);
     } else if (allSuggestions.length > 0) {
       isValid =
         allSuggestions.includes(variableId) ||
@@ -152,6 +204,8 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
     onUpdateAttributes,
     variableValidation,
     isInsideLoop,
+    isLiquid,
+    freeform,
   ]);
 
   // Focus and place cursor at end when entering edit mode
@@ -194,14 +248,21 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
 
     const context = { isInsideLoop };
 
+    // Free-form chips (Liquid tags) accept any non-empty content.
+    if (freeform) {
+      onUpdateAttributes({ id: trimmedValue, isInvalid: false });
+      onCommit?.();
+      return;
+    }
+
     if (variableValidation?.overrideFormatValidation) {
       if (variableValidation.validate) {
         isValid = variableValidation.validate(trimmedValue, context);
         if (!isValid) customValidationFailed = true;
       }
     } else {
-      // Format validation first
-      isValid = isValidVariableName(trimmedValue);
+      // Format validation first (engine-aware: Liquid allows filters/brackets)
+      isValid = isValidVariableName(trimmedValue, renderEngine);
 
       // Custom validation only if format passes
       if (isValid && variableValidation?.validate) {
@@ -210,8 +271,9 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
       }
     }
 
-    // List check — skip when a custom validator is provided
-    if (isValid && allSuggestions.length > 0 && !variableValidation?.validate) {
+    // List check — skip when a custom validator is provided, and under Liquid
+    // (filter/bracket expressions won't be literal suggestion-list members).
+    if (isValid && allSuggestions.length > 0 && !variableValidation?.validate && !isLiquid) {
       isValid = allSuggestions.includes(trimmedValue);
     }
 
@@ -245,7 +307,17 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
       isInvalid: false,
     });
     onCommit?.();
-  }, [onDelete, onUpdateAttributes, variableValidation, allSuggestions, onCommit, isInsideLoop]);
+  }, [
+    onDelete,
+    onUpdateAttributes,
+    variableValidation,
+    allSuggestions,
+    onCommit,
+    isInsideLoop,
+    renderEngine,
+    isLiquid,
+    freeform,
+  ]);
 
   // Handle selecting an item from autocomplete
   const handleSelectSuggestion = useCallback(
@@ -318,6 +390,8 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
         }
         if (e.key === "Enter") {
           e.preventDefault();
+          // Keep Enter from reaching the editor keymap while editing the chip.
+          e.stopPropagation();
           const selected = filteredSuggestions[selectedIndex];
           if (selected) {
             handleSelectSuggestion(selected);
@@ -336,6 +410,8 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
         }
       } else if (e.key === "Enter") {
         e.preventDefault();
+        // Keep Enter from reaching the editor keymap while editing the chip.
+        e.stopPropagation();
         editableRef.current?.blur();
         return;
       }
@@ -379,8 +455,8 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
     if (editableRef.current) {
       let text = editableRef.current.textContent || "";
       // Enforce max length
-      if (text.length > MAX_VARIABLE_LENGTH) {
-        text = text.slice(0, MAX_VARIABLE_LENGTH);
+      if (text.length > maxLen) {
+        text = text.slice(0, maxLen);
         editableRef.current.textContent = text;
         // Move cursor to end
         const range = document.createRange();
@@ -394,13 +470,13 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
       setQuery(text);
       setSelectedIndex(0);
     }
-  }, []);
+  }, [maxLen]);
 
   // Handle paste to strip formatting and enforce max length
   const handlePaste = useCallback(
     (e: React.ClipboardEvent) => {
       e.preventDefault();
-      const text = e.clipboardData.getData("text/plain").slice(0, MAX_VARIABLE_LENGTH);
+      const text = e.clipboardData.getData("text/plain").slice(0, maxLen);
 
       // Use modern Range API instead of deprecated document.execCommand
       const selection = window.getSelection();
@@ -420,7 +496,7 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
         handleInput();
       }
     },
-    [handleInput]
+    [handleInput, maxLen]
   );
 
   const handleEditTrigger = useCallback(
@@ -438,11 +514,13 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
 
   // Truncate display text and prepare title for tooltip
   const displayInfo = useMemo(() => {
+    // Liquid tags tend to be longer than variable names; allow more before truncating.
+    const displayLimit = freeform ? 40 : MAX_DISPLAY_LENGTH;
     const name = variableId;
     const valueStr = value ? `="${value}"` : "";
     const fullText = `${name}${valueStr}`;
-    const isTruncated = name.length > MAX_DISPLAY_LENGTH;
-    const displayName = isTruncated ? `${name.slice(0, MAX_DISPLAY_LENGTH)}…` : name;
+    const isTruncated = name.length > displayLimit;
+    const displayName = isTruncated ? `${name.slice(0, displayLimit)}…` : name;
     const displayText = `${displayName}${valueStr}`;
 
     return {
@@ -450,7 +528,7 @@ export const VariableChipBase: React.FC<VariableChipBaseProps> = ({
       fullText,
       showTitle: isTruncated,
     };
-  }, [variableId, value]);
+  }, [variableId, value, freeform]);
 
   // Update span content when not editing - show displayText (name + value) instead of just name
   useEffect(() => {

--- a/packages/react-designer/src/components/utils/validateVariableName.test.ts
+++ b/packages/react-designer/src/components/utils/validateVariableName.test.ts
@@ -90,4 +90,64 @@ describe("isValidVariableName", () => {
       expect(isValidVariableName("  user. firstName  ")).toBe(false);
     });
   });
+
+  describe("Liquid engine", () => {
+    it("should accept namespaced variable paths", () => {
+      expect(isValidVariableName("data.name", "liquid")).toBe(true);
+      expect(isValidVariableName("data.user.firstName", "liquid")).toBe(true);
+      expect(isValidVariableName("profile.email", "liquid")).toBe(true);
+      expect(isValidVariableName("brand.colors.primary", "liquid")).toBe(true);
+      expect(isValidVariableName("urls.unsubscribe", "liquid")).toBe(true);
+    });
+
+    it("should flag bare (non-namespaced) names — they don't resolve in Liquid", () => {
+      expect(isValidVariableName("name", "liquid")).toBe(false);
+      expect(isValidVariableName("user.firstName", "liquid")).toBe(false);
+      expect(isValidVariableName("firstName", "liquid")).toBe(false);
+    });
+
+    it("should accept bracket indexing", () => {
+      expect(isValidVariableName("data.items[0]", "liquid")).toBe(true);
+      expect(isValidVariableName("data.items[0].name", "liquid")).toBe(true);
+      expect(isValidVariableName("data['first name']", "liquid")).toBe(true);
+      expect(isValidVariableName('data["key"].value', "liquid")).toBe(true);
+    });
+
+    it("should accept negative and variable bracket indices", () => {
+      expect(isValidVariableName("data.items[-1]", "liquid")).toBe(true);
+      expect(isValidVariableName("data[data.i]", "liquid")).toBe(true);
+      expect(isValidVariableName("data.items[data.idx].name", "liquid")).toBe(true);
+    });
+
+    it("should accept filters", () => {
+      expect(isValidVariableName("data.name | upcase", "liquid")).toBe(true);
+      expect(isValidVariableName("data.price | times: 1.1", "liquid")).toBe(true);
+      expect(isValidVariableName('data.date | date: "%Y"', "liquid")).toBe(true);
+      expect(isValidVariableName("data.name | upcase | truncate: 10", "liquid")).toBe(true);
+    });
+
+    it("should not be confused by pipes inside quoted filter args", () => {
+      expect(isValidVariableName('data.name | default: "a|b"', "liquid")).toBe(true);
+    });
+
+    it("should still reject malformed expressions", () => {
+      expect(isValidVariableName("data.", "liquid")).toBe(false);
+      expect(isValidVariableName("data..name", "liquid")).toBe(false);
+      expect(isValidVariableName("data.name |", "liquid")).toBe(false);
+      expect(isValidVariableName("", "liquid")).toBe(false);
+    });
+
+    it("should not flag loop references", () => {
+      expect(isValidVariableName("$.item.name", "liquid")).toBe(true);
+    });
+
+    it("should not change Handlebars behavior (default)", () => {
+      // Bare names remain valid under the default engine.
+      expect(isValidVariableName("name")).toBe(true);
+      expect(isValidVariableName("user.firstName")).toBe(true);
+      // Filters/brackets remain invalid under Handlebars.
+      expect(isValidVariableName("data.name | upcase")).toBe(false);
+      expect(isValidVariableName("data.items[0]")).toBe(false);
+    });
+  });
 });

--- a/packages/react-designer/src/components/utils/validateVariableName.ts
+++ b/packages/react-designer/src/components/utils/validateVariableName.ts
@@ -1,3 +1,12 @@
+import type { RenderEngine } from "@/types";
+
+/**
+ * Root namespaces whose variables resolve under Liquid. Send variables are
+ * exposed only via `data.*`; `profile`/`brand`/`urls` are named globals.
+ * (See the backend's Liquid render engine: data-only variable access.)
+ */
+export const LIQUID_VARIABLE_ROOTS = ["data", "profile", "brand", "urls"];
+
 /**
  * Validates a variable name according to JSON property name rules.
  * Also allows `$` as a valid identifier character to support loop
@@ -7,9 +16,14 @@
  * Invalid: user. firstName (space), user. (trailing dot), user..name (double dot), 123invalid (starts with digit)
  *
  * @param variableName - The variable name to validate (without curly braces)
+ * @param engine - The rendering engine. Liquid permits filters, bracket
+ *   indexing, and requires a known namespace root. Defaults to Handlebars.
  * @returns true if the variable name is valid, false otherwise
  */
-export function isValidVariableName(variableName: string): boolean {
+export function isValidVariableName(
+  variableName: string,
+  engine: RenderEngine = "handlebars"
+): boolean {
   // Remove leading/trailing whitespace for validation
   const trimmed = variableName.trim();
 
@@ -18,6 +32,15 @@ export function isValidVariableName(variableName: string): boolean {
     return false;
   }
 
+  if (engine === "liquid") {
+    return isValidLiquidExpression(trimmed);
+  }
+
+  return isValidHandlebarsName(trimmed);
+}
+
+/** Handlebars rules: dotted identifier paths, no filters or brackets. */
+function isValidHandlebarsName(trimmed: string): boolean {
   // Cannot start or end with a dot
   if (trimmed.startsWith(".") || trimmed.endsWith(".")) {
     return false;
@@ -53,4 +76,94 @@ export function isValidVariableName(variableName: string): boolean {
   }
 
   return true;
+}
+
+/**
+ * Liquid rules: a variable path (with optional dot/bracket access) rooted in a
+ * known namespace, optionally followed by one or more filters.
+ * Examples: `data.name`, `data.items[0].title`, `data['key']`,
+ *   `data.price | times: 1.1`, `data.name | upcase | truncate: 10`.
+ */
+function isValidLiquidExpression(expr: string): boolean {
+  const [pathPart, ...filterParts] = splitTopLevelPipes(expr);
+
+  if (!isValidLiquidPath(pathPart.trim())) {
+    return false;
+  }
+
+  return filterParts.every((filter) => isValidLiquidFilter(filter.trim()));
+}
+
+// Leading identifier (the root segment) of a variable path.
+const ROOT_SEGMENT_REGEX = /^[a-zA-Z_$][a-zA-Z0-9_$]*/;
+
+// A variable path: a root identifier followed by any mix of `.segment`,
+// `[<int>]` (incl. negative), `['key']`, `["key"]`, or `[var.path]` access.
+const LIQUID_PATH_REGEX =
+  /^[a-zA-Z_$][a-zA-Z0-9_$]*((\.[a-zA-Z_$][a-zA-Z0-9_$]*)|(\[\s*-?\d+\s*\])|(\[\s*'[^']*'\s*\])|(\[\s*"[^"]*"\s*\])|(\[\s*[a-zA-Z_$][a-zA-Z0-9_$.]*\s*\]))*$/;
+
+/** Root (first) segment of a variable path, e.g. `data` from `data.items[0]`. */
+function rootSegment(path: string): string {
+  return ROOT_SEGMENT_REGEX.exec(path)?.[0] ?? "";
+}
+
+function isValidLiquidPath(path: string): boolean {
+  if (!path || !LIQUID_PATH_REGEX.test(path)) {
+    return false;
+  }
+  const root = rootSegment(path);
+  // Send variables resolve only under a known namespace root; `$` keeps loop
+  // references from being flagged.
+  return LIQUID_VARIABLE_ROOTS.includes(root) || root === "$";
+}
+
+/**
+ * Lenient filter check: a filter name, optionally followed by `: args`. Argument
+ * shapes are not deeply validated — the renderer fails loud on truly invalid
+ * filters; the editor's job is only to avoid red-flagging legitimate Liquid.
+ */
+function isValidLiquidFilter(filter: string): boolean {
+  return /^[a-zA-Z_][a-zA-Z0-9_]*\s*(:\s*\S.*)?$/.test(filter);
+}
+
+/** Split on top-level `|` pipes, ignoring pipes inside single/double quotes. */
+function splitTopLevelPipes(expr: string): string[] {
+  const result: string[] = [];
+  let current = "";
+  let quote: string | null = null;
+
+  for (const ch of expr) {
+    if (quote) {
+      current += ch;
+      if (ch === quote) quote = null;
+    } else if (ch === "'" || ch === '"') {
+      quote = ch;
+      current += ch;
+    } else if (ch === "|") {
+      result.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+
+  result.push(current);
+  return result;
+}
+
+/**
+ * Ensures a variable name is rooted in a Liquid namespace. Names already rooted
+ * in a known namespace (or loop `$`) are returned unchanged; bare names are
+ * prefixed with `data.` so they resolve under Liquid's data-only access.
+ */
+export function ensureLiquidNamespace(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  const root = rootSegment(trimmed);
+  if (LIQUID_VARIABLE_ROOTS.includes(root) || root === "$") {
+    return trimmed;
+  }
+  return `data.${trimmed}`;
 }

--- a/packages/react-designer/src/index.ts
+++ b/packages/react-designer/src/index.ts
@@ -19,7 +19,7 @@ export * from "./components/ui-kit/ErrorBoundary";
 
 export { CHANNELS } from "@/channels";
 export type { ChannelType } from "@/store";
-export type { ElementalContent } from "@/types";
+export type { ElementalContent, ElementalRenderOptions, RenderEngine } from "@/types";
 
 export { PreviewPanel } from "@/components/ui/PreviewPanel";
 export { Tooltip } from "@/components/ui/Tooltip";

--- a/packages/react-designer/src/lib/utils/coalesceTextRuns.test.ts
+++ b/packages/react-designer/src/lib/utils/coalesceTextRuns.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { coalesceTextRuns } from "./coalesceTextRuns";
+
+describe("coalesceTextRuns", () => {
+  it("merges adjacent same-formatting string elements", () => {
+    const result = coalesceTextRuns({
+      type: "text",
+      elements: [
+        { type: "string", content: "Hello " },
+        { type: "string", content: "{{ data.name }}" },
+        { type: "string", content: ", welcome!" },
+      ],
+    });
+    expect(result.elements).toEqual([
+      { type: "string", content: "Hello {{ data.name }}, welcome!" },
+    ]);
+  });
+
+  it("merges a fragmented Liquid if/else block into one field", () => {
+    // The shape convertTiptapToElemental produces for:
+    //   {% if data.name %}{{ data.name }}{% else %} GetBent {% endif %}
+    const result = coalesceTextRuns({
+      type: "text",
+      align: "left",
+      elements: [
+        { type: "string", content: "{% if data.name %}" },
+        { type: "string", content: " " },
+        { type: "string", content: "{{ data.name }}" },
+        { type: "string", content: " " },
+        { type: "string", content: "{% else %}" },
+        { type: "string", content: " GetBent " },
+        { type: "string", content: "{% endif %}" },
+        { type: "string", content: " " },
+      ],
+    });
+    expect(result.elements).toEqual([
+      {
+        type: "string",
+        content: "{% if data.name %} {{ data.name }} {% else %} GetBent {% endif %} ",
+      },
+    ]);
+  });
+
+  it("does not merge across a formatting boundary", () => {
+    const result = coalesceTextRuns({
+      type: "text",
+      elements: [
+        { type: "string", content: "plain " },
+        { type: "string", content: "bold", bold: true },
+        { type: "string", content: " plain" },
+      ],
+    });
+    expect(result.elements).toEqual([
+      { type: "string", content: "plain " },
+      { type: "string", content: "bold", bold: true },
+      { type: "string", content: " plain" },
+    ]);
+  });
+
+  it("does not merge across non-string elements (links)", () => {
+    const result = coalesceTextRuns({
+      type: "text",
+      elements: [
+        { type: "string", content: "a" },
+        { type: "link", content: "link", href: "https://x.com" },
+        { type: "string", content: "b" },
+      ],
+    });
+    expect((result.elements as unknown[]).length).toBe(3);
+  });
+
+  it("recurses into nested channel/text elements", () => {
+    const result = coalesceTextRuns({
+      version: "2022-01-01",
+      elements: [
+        {
+          type: "channel",
+          channel: "email",
+          elements: [
+            {
+              type: "text",
+              elements: [
+                { type: "string", content: "{% if x %}" },
+                { type: "string", content: "{% endif %}" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    // @ts-expect-error nested test shape
+    expect(result.elements[0].elements[0].elements).toEqual([
+      { type: "string", content: "{% if x %}{% endif %}" },
+    ]);
+  });
+
+  it("leaves a single string element unchanged", () => {
+    const result = coalesceTextRuns({
+      type: "text",
+      elements: [{ type: "string", content: "{{ data.name }}" }],
+    });
+    expect(result.elements).toEqual([{ type: "string", content: "{{ data.name }}" }]);
+  });
+});

--- a/packages/react-designer/src/lib/utils/coalesceTextRuns.ts
+++ b/packages/react-designer/src/lib/utils/coalesceTextRuns.ts
@@ -1,0 +1,61 @@
+/**
+ * Formatting flags that distinguish one inline text run from another. Two
+ * adjacent `string` elements may only merge when all of these match — merging
+ * across a formatting boundary would change rendering.
+ */
+const FLAG_KEYS = ["bold", "italic", "strikethrough", "underline", "color"] as const;
+
+type StringEl = { type: "string"; content?: string } & Record<string, unknown>;
+
+function isStringEl(value: unknown): value is StringEl {
+  return (
+    Boolean(value) && typeof value === "object" && (value as { type?: string }).type === "string"
+  );
+}
+
+function sameFlags(a: StringEl, b: StringEl): boolean {
+  return FLAG_KEYS.every((key) => a[key] === b[key]);
+}
+
+/** Merge consecutive same-formatting `string` elements within one elements array. */
+function coalesceStringRun(elements: unknown[]): unknown[] {
+  const result: unknown[] = [];
+  for (const el of elements) {
+    const prev = result[result.length - 1];
+    if (isStringEl(el) && isStringEl(prev) && sameFlags(prev, el)) {
+      result[result.length - 1] = { ...prev, content: (prev.content ?? "") + (el.content ?? "") };
+    } else {
+      result.push(el);
+    }
+  }
+  return result;
+}
+
+/**
+ * Recursively merges adjacent `string` elements (with identical formatting) in
+ * every `elements` array of the content tree, so a text run that was split into
+ * many pieces — text, `{{ variables }}`, `{% tags %}` — becomes a single string.
+ *
+ * This matters for Liquid: the renderer interpolates each `string` element as
+ * its own field, so a `{% if %}…{% endif %}` block split across elements is
+ * invalid. Coalescing puts the whole run in one field. (Pieces in different
+ * formatting runs still can't share a Liquid block — a per-field limitation.)
+ */
+export function coalesceTextRuns<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => coalesceTextRuns(item)) as unknown as T;
+  }
+
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      result[key] = coalesceTextRuns(val);
+    }
+    if (Array.isArray(result.elements)) {
+      result.elements = coalesceStringRun(result.elements);
+    }
+    return result as T;
+  }
+
+  return value;
+}

--- a/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.test.tsx
+++ b/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.test.tsx
@@ -216,6 +216,51 @@ describe("parseMDContent", () => {
     expect(result).toEqual([]);
   });
 
+  describe("Liquid tags ({% %})", () => {
+    it("should parse a liquid tag into a liquidTag node (Liquid engine)", () => {
+      const result = parseMDContent("Hi {% if data.vip %}!", "liquid");
+
+      expect(result).toContainEqual({ type: "text", text: "Hi " });
+      expect(result).toContainEqual({
+        type: "liquidTag",
+        attrs: { content: "if data.vip" },
+      });
+      expect(result).toContainEqual({ type: "text", text: "!" });
+    });
+
+    it("should parse tags alongside variables", () => {
+      const result = parseMDContent("{% if data.vip %}Hi {{ data.name }}{% endif %}", "liquid");
+
+      expect(result).toContainEqual({ type: "liquidTag", attrs: { content: "if data.vip" } });
+      expect(result).toContainEqual({
+        type: "variable",
+        attrs: { id: "data.name", isInvalid: false },
+      });
+      expect(result).toContainEqual({ type: "liquidTag", attrs: { content: "endif" } });
+    });
+
+    it("should trim inner whitespace from tag content", () => {
+      const result = parseMDContent("{%   assign x = 1   %}", "liquid");
+      expect(result).toContainEqual({ type: "liquidTag", attrs: { content: "assign x = 1" } });
+    });
+
+    it("should NOT match a tag whose quoted arg contains %}", () => {
+      const result = parseMDContent("{% assign x = data.s | split: '%}' %}", "liquid");
+      expect(result).toContainEqual({
+        type: "liquidTag",
+        attrs: { content: "assign x = data.s | split: '%}'" },
+      });
+    });
+
+    it("should leave {% %} as plain text under Handlebars (default)", () => {
+      const result = parseMDContent("Hi {% if data.vip %}!");
+      expect(result).not.toContainEqual(expect.objectContaining({ type: "liquidTag" }));
+      expect(result.some((n) => n.type === "text" && n.text?.includes("{% if data.vip %}"))).toBe(
+        true
+      );
+    });
+  });
+
   describe("consecutive asterisks handling", () => {
     it("should preserve triple asterisks as literal text", () => {
       const content = "*** some text";
@@ -1834,7 +1879,6 @@ describe("convertElementalToTiptap", () => {
     });
   });
 
-
   describe("Columns Frame/Border parsing", () => {
     it("should parse columns with all Frame and Border attributes", () => {
       const elemental = createElementalContent([
@@ -2490,9 +2534,7 @@ describe("convertElementalToTiptap", () => {
       const elemental = createElementalContent([
         {
           type: "text",
-          elements: [
-            { type: "string", content: "{{status}}", color: "#ff0000" },
-          ],
+          elements: [{ type: "string", content: "{{status}}", color: "#ff0000" }],
         } as any,
       ]);
 
@@ -2501,9 +2543,7 @@ describe("convertElementalToTiptap", () => {
       const variableNode = result.content[0].content![0];
       expect(variableNode.type).toBe("variable");
       expect(variableNode.marks).toEqual(
-        expect.arrayContaining([
-          { type: "textStyle", attrs: { color: "#ff0000" } },
-        ])
+        expect.arrayContaining([{ type: "textStyle", attrs: { color: "#ff0000" } }])
       );
     });
 
@@ -2544,9 +2584,7 @@ describe("convertElementalToTiptap", () => {
       expect(result.content[0].content![1]).toMatchObject({
         type: "text",
         text: "Google",
-        marks: expect.arrayContaining([
-          { type: "link", attrs: { href: "https://google.com" } },
-        ]),
+        marks: expect.arrayContaining([{ type: "link", attrs: { href: "https://google.com" } }]),
       });
     });
 
@@ -2651,9 +2689,10 @@ describe("convertElementalToTiptap", () => {
       ]);
 
       const elemental = convertTiptapToElemental(tiptap);
-      const roundTripped = convertElementalToTiptap(
-        { version: "2022-01-01", elements: [{ type: "channel", channel: "email", elements: elemental } as any] }
-      );
+      const roundTripped = convertElementalToTiptap({
+        version: "2022-01-01",
+        elements: [{ type: "channel", channel: "email", elements: elemental } as any],
+      });
 
       expect(roundTripped.content).toHaveLength(1);
       expect(roundTripped.content[0].type).toBe("paragraph");
@@ -2684,9 +2723,10 @@ describe("convertElementalToTiptap", () => {
       ]);
 
       const elemental = convertTiptapToElemental(tiptap);
-      const roundTripped = convertElementalToTiptap(
-        { version: "2022-01-01", elements: [{ type: "channel", channel: "email", elements: elemental } as any] }
-      );
+      const roundTripped = convertElementalToTiptap({
+        version: "2022-01-01",
+        elements: [{ type: "channel", channel: "email", elements: elemental } as any],
+      });
 
       expect(roundTripped.content[0].content).toHaveLength(1);
       const node = roundTripped.content[0].content![0];
@@ -2713,9 +2753,10 @@ describe("convertElementalToTiptap", () => {
       ]);
 
       const elemental = convertTiptapToElemental(tiptap);
-      const roundTripped = convertElementalToTiptap(
-        { version: "2022-01-01", elements: [{ type: "channel", channel: "email", elements: elemental } as any] }
-      );
+      const roundTripped = convertElementalToTiptap({
+        version: "2022-01-01",
+        elements: [{ type: "channel", channel: "email", elements: elemental } as any],
+      });
 
       expect(roundTripped.content[0].content).toHaveLength(2);
       expect(roundTripped.content[0].content![0]).toMatchObject({
@@ -2742,9 +2783,10 @@ describe("convertElementalToTiptap", () => {
       ]);
 
       const elemental = convertTiptapToElemental(tiptap);
-      const roundTripped = convertElementalToTiptap(
-        { version: "2022-01-01", elements: [{ type: "channel", channel: "email", elements: elemental } as any] }
-      );
+      const roundTripped = convertElementalToTiptap({
+        version: "2022-01-01",
+        elements: [{ type: "channel", channel: "email", elements: elemental } as any],
+      });
 
       expect(roundTripped.content[0].content).toHaveLength(3);
       expect(roundTripped.content[0].content![0]).toMatchObject({ type: "text", text: "normal" });
@@ -2779,9 +2821,10 @@ describe("convertElementalToTiptap", () => {
       ]);
 
       // Round-trip back to TipTap
-      const roundTripped = convertElementalToTiptap(
-        { version: "2022-01-01", elements: [{ type: "channel", channel: "email", elements: elemental } as any] }
-      );
+      const roundTripped = convertElementalToTiptap({
+        version: "2022-01-01",
+        elements: [{ type: "channel", channel: "email", elements: elemental } as any],
+      });
 
       expect(roundTripped.content[0].content).toHaveLength(3);
       expect(roundTripped.content[0].content![0]).toMatchObject({ type: "text", text: "Hello " });
@@ -2790,7 +2833,10 @@ describe("convertElementalToTiptap", () => {
         attrs: expect.objectContaining({ id: "userName" }),
         marks: [{ type: "bold" }],
       });
-      expect(roundTripped.content[0].content![2]).toMatchObject({ type: "text", text: " and welcome!" });
+      expect(roundTripped.content[0].content![2]).toMatchObject({
+        type: "text",
+        text: " and welcome!",
+      });
     });
 
     it("should round-trip variable with all formatting marks", () => {
@@ -2801,7 +2847,12 @@ describe("convertElementalToTiptap", () => {
             {
               type: "variable",
               attrs: { id: "name" },
-              marks: [{ type: "bold" }, { type: "italic" }, { type: "underline" }, { type: "strike" }],
+              marks: [
+                { type: "bold" },
+                { type: "italic" },
+                { type: "underline" },
+                { type: "strike" },
+              ],
             },
           ],
         },
@@ -2818,9 +2869,10 @@ describe("convertElementalToTiptap", () => {
         strikethrough: true,
       });
 
-      const roundTripped = convertElementalToTiptap(
-        { version: "2022-01-01", elements: [{ type: "channel", channel: "email", elements: elemental } as any] }
-      );
+      const roundTripped = convertElementalToTiptap({
+        version: "2022-01-01",
+        elements: [{ type: "channel", channel: "email", elements: elemental } as any],
+      });
 
       const variableNode = roundTripped.content[0].content![0];
       expect(variableNode.type).toBe("variable");
@@ -2844,9 +2896,7 @@ describe("convertElementalToTiptap", () => {
           {
             type: "channel",
             channel: "email",
-            elements: [
-              { type: "text", content: "This is **bold** text\n" },
-            ],
+            elements: [{ type: "text", content: "This is **bold** text\n" }],
           } as any,
         ],
       };
@@ -2899,9 +2949,7 @@ describe("convertElementalToTiptap", () => {
           {
             type: "channel",
             channel: "email",
-            elements: [
-              { type: "text", content: "Hello {{user}}\n" },
-            ],
+            elements: [{ type: "text", content: "Hello {{user}}\n" }],
           } as any,
         ],
       };
@@ -2926,9 +2974,7 @@ describe("convertElementalToTiptap", () => {
           {
             type: "channel",
             channel: "email",
-            elements: [
-              { type: "text", content: "Line 1\nLine 2\nLine 3\n" },
-            ],
+            elements: [{ type: "text", content: "Line 1\nLine 2\nLine 3\n" }],
           } as any,
         ],
       };
@@ -2953,9 +2999,7 @@ describe("convertElementalToTiptap", () => {
       const elemental = createElementalContent([
         {
           type: "text",
-          elements: [
-            { type: "string", content: "red text", color: "#ff0000" },
-          ],
+          elements: [{ type: "string", content: "red text", color: "#ff0000" }],
         } as any,
       ]);
 
@@ -2965,9 +3009,7 @@ describe("convertElementalToTiptap", () => {
       const node = result.content[0].content![0];
       expect(node.text).toBe("red text");
       expect(node.marks).toEqual(
-        expect.arrayContaining([
-          { type: "textStyle", attrs: { color: "#ff0000" } },
-        ])
+        expect.arrayContaining([{ type: "textStyle", attrs: { color: "#ff0000" } }])
       );
     });
 
@@ -2975,9 +3017,7 @@ describe("convertElementalToTiptap", () => {
       const elemental = createElementalContent([
         {
           type: "text",
-          elements: [
-            { type: "string", content: "bold red", bold: true, color: "#ff0000" },
-          ],
+          elements: [{ type: "string", content: "bold red", bold: true, color: "#ff0000" }],
         } as any,
       ]);
 
@@ -3024,9 +3064,7 @@ describe("convertElementalToTiptap", () => {
       const elemental = createElementalContent([
         {
           type: "text",
-          elements: [
-            { type: "string", content: "plain text" },
-          ],
+          elements: [{ type: "string", content: "plain text" }],
         } as any,
       ]);
 
@@ -3069,9 +3107,7 @@ describe("convertElementalToTiptap", () => {
         {
           type: "text",
           text_style: "h1",
-          elements: [
-            { type: "string", content: "colored heading", color: "#0000ff" },
-          ],
+          elements: [{ type: "string", content: "colored heading", color: "#0000ff" }],
         } as any,
       ]);
 
@@ -3089,9 +3125,7 @@ describe("convertElementalToTiptap", () => {
       const elemental = createElementalContent([
         {
           type: "text",
-          elements: [
-            { type: "string", content: "brand colored", color: "{brand.colors.primary}" },
-          ],
+          elements: [{ type: "string", content: "brand colored", color: "{brand.colors.primary}" }],
         } as any,
       ]);
 
@@ -3108,9 +3142,7 @@ describe("convertElementalToTiptap", () => {
       const elemental = createElementalContent([
         {
           type: "text",
-          elements: [
-            { type: "string", content: "secondary", color: "{brand.colors.secondary}" },
-          ],
+          elements: [{ type: "string", content: "secondary", color: "{brand.colors.secondary}" }],
         } as any,
       ]);
 
@@ -3140,9 +3172,7 @@ describe("convertElementalToTiptap", () => {
       expect(nodes[0].marks).toEqual([
         { type: "textStyle", attrs: { color: "{brand.colors.primary}" } },
       ]);
-      expect(nodes[1].marks).toEqual([
-        { type: "textStyle", attrs: { color: "#ff0000" } },
-      ]);
+      expect(nodes[1].marks).toEqual([{ type: "textStyle", attrs: { color: "#ff0000" } }]);
     });
 
     it("should preserve brand color ref on link element", () => {
@@ -3177,9 +3207,7 @@ describe("convertElementalToTiptap", () => {
       const elemental = createElementalContent([
         {
           type: "text",
-          elements: [
-            { type: "string", content: "before\n\n\nafter" },
-          ],
+          elements: [{ type: "string", content: "before\n\n\nafter" }],
         } as any,
       ]);
 
@@ -3237,9 +3265,7 @@ describe("convertElementalToTiptap", () => {
         text: "Visit ",
       });
       expect(result.content[0].content![0].marks).toEqual(
-        expect.arrayContaining([
-          { type: "link", attrs: { href: "https://example.com" } },
-        ])
+        expect.arrayContaining([{ type: "link", attrs: { href: "https://example.com" } }])
       );
       expect(result.content[0].content![1]).toMatchObject({
         type: "variable",
@@ -3305,9 +3331,7 @@ describe("convertElementalToTiptap", () => {
           locales: {
             fr: { content: "Bonjour" },
             es: {
-              elements: [
-                { type: "string", content: "Hola", bold: true },
-              ],
+              elements: [{ type: "string", content: "Hola", bold: true }],
             },
           },
         } as any,
@@ -3318,9 +3342,7 @@ describe("convertElementalToTiptap", () => {
       expect(result.content[0].attrs?.locales).toEqual({
         fr: { content: "Bonjour" },
         es: {
-          elements: [
-            { type: "string", content: "Hola", bold: true },
-          ],
+          elements: [{ type: "string", content: "Hola", bold: true }],
         },
       });
     });
@@ -3337,16 +3359,15 @@ describe("convertElementalToTiptap", () => {
         {
           type: "heading",
           attrs: { level: 1, textAlign: "center" },
-          content: [
-            { type: "text", text: "Bold heading", marks: [{ type: "bold" }] },
-          ],
+          content: [{ type: "text", text: "Bold heading", marks: [{ type: "bold" }] }],
         },
       ]);
 
       const elemental = convertTiptapToElemental(tiptap);
-      const roundTripped = convertElementalToTiptap(
-        { version: "2022-01-01", elements: [{ type: "channel", channel: "email", elements: elemental } as any] }
-      );
+      const roundTripped = convertElementalToTiptap({
+        version: "2022-01-01",
+        elements: [{ type: "channel", channel: "email", elements: elemental } as any],
+      });
 
       expect(roundTripped.content[0].type).toBe("heading");
       expect(roundTripped.content[0].attrs?.level).toBe(1);
@@ -3373,9 +3394,10 @@ describe("convertElementalToTiptap", () => {
       ]);
 
       const elemental = convertTiptapToElemental(tiptap);
-      const roundTripped = convertElementalToTiptap(
-        { version: "2022-01-01", elements: [{ type: "channel", channel: "email", elements: elemental } as any] }
-      );
+      const roundTripped = convertElementalToTiptap({
+        version: "2022-01-01",
+        elements: [{ type: "channel", channel: "email", elements: elemental } as any],
+      });
 
       expect(roundTripped.content[0].content![0]).toMatchObject({
         type: "text",
@@ -3403,9 +3425,10 @@ describe("convertElementalToTiptap", () => {
       ]);
 
       const elemental = convertTiptapToElemental(tiptap);
-      const roundTripped = convertElementalToTiptap(
-        { version: "2022-01-01", elements: [{ type: "channel", channel: "email", elements: elemental } as any] }
-      );
+      const roundTripped = convertElementalToTiptap({
+        version: "2022-01-01",
+        elements: [{ type: "channel", channel: "email", elements: elemental } as any],
+      });
 
       const node = roundTripped.content[0].content![0];
       expect(node.text).toBe("styled link");
@@ -3435,9 +3458,10 @@ describe("convertElementalToTiptap", () => {
       ]);
 
       const elemental = convertTiptapToElemental(tiptap);
-      const roundTripped = convertElementalToTiptap(
-        { version: "2022-01-01", elements: [{ type: "channel", channel: "email", elements: elemental } as any] }
-      );
+      const roundTripped = convertElementalToTiptap({
+        version: "2022-01-01",
+        elements: [{ type: "channel", channel: "email", elements: elemental } as any],
+      });
 
       const nodes = roundTripped.content[0].content!;
       expect(nodes).toHaveLength(3);
@@ -3529,9 +3553,10 @@ describe("convertElementalToTiptap", () => {
       ]);
 
       const elemental = convertTiptapToElemental(tiptap);
-      const roundTripped = convertElementalToTiptap(
-        { version: "2022-01-01", elements: [{ type: "channel", channel: "email", elements: elemental } as any] }
-      );
+      const roundTripped = convertElementalToTiptap({
+        version: "2022-01-01",
+        elements: [{ type: "channel", channel: "email", elements: elemental } as any],
+      });
 
       expect(roundTripped.content[0].content).toHaveLength(4);
       expect(roundTripped.content[0].content![0]).toMatchObject({ type: "text", text: "before" });
@@ -3576,9 +3601,7 @@ describe("convertElementalToTiptap", () => {
       expect(paraContent[1]).toMatchObject({
         type: "text",
         text: "google",
-        marks: expect.arrayContaining([
-          { type: "link", attrs: { href: "https://google.com" } },
-        ]),
+        marks: expect.arrayContaining([{ type: "link", attrs: { href: "https://google.com" } }]),
       });
       expect(paraContent[2]).toMatchObject({ type: "text", text: " and welcome!" });
     });
@@ -3692,9 +3715,7 @@ describe("convertElementalToTiptap", () => {
       expect(paraContent[1]).toMatchObject({
         type: "text",
         text: "google",
-        marks: expect.arrayContaining([
-          { type: "link", attrs: { href: "https://google.com" } },
-        ]),
+        marks: expect.arrayContaining([{ type: "link", attrs: { href: "https://google.com" } }]),
       });
       expect(paraContent[2]).toMatchObject({ type: "text", text: " and welcome!" });
     });
@@ -3987,9 +4008,7 @@ describe("convertElementalToTiptap", () => {
           type: "list",
           list_type: "unordered",
           if: "{= data.show_list}",
-          elements: [
-            { type: "list-item", elements: [{ type: "string", content: "item" }] },
-          ],
+          elements: [{ type: "list-item", elements: [{ type: "string", content: "item" }] }],
         } as any,
       ]);
       const tiptap = convertElementalToTiptap(elemental);
@@ -3998,13 +4017,10 @@ describe("convertElementalToTiptap", () => {
     });
 
     it("should not include if when absent", () => {
-      const elemental = createElementalContent([
-        { type: "text", content: "No condition" } as any,
-      ]);
+      const elemental = createElementalContent([{ type: "text", content: "No condition" } as any]);
       const tiptap = convertElementalToTiptap(elemental);
       const result = convertTiptapToElemental(tiptap);
       expect((result[0] as any).if).toBeUndefined();
     });
   });
-
 });

--- a/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
+++ b/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
@@ -4,13 +4,27 @@ import type {
   ElementalNode,
   ElementalContent,
   ElementalTextContentNode,
+  RenderEngine,
   TiptapDoc,
 } from "../../../types";
 import { v4 as uuidv4 } from "uuid";
 import { isValidVariableName } from "@/components/utils/validateVariableName";
+import { LIQUID_TAG_TOKEN_SOURCE } from "../liquidTagToken";
 import { isBlankImageSrc } from "../image";
 import { defaultButtonProps } from "@/components/extensions/Button/Button";
 import { INBOX_FILLED, INBOX_OUTLINED } from "@/components/extensions/Button/inboxButtonStyle";
+
+/**
+ * Token matcher for a parse pass. `{{ }}` variables are always recognized;
+ * `{% %}` Liquid tags are recognized only under the Liquid engine so existing
+ * Handlebars templates with literal `{% %}` text are left as plain text.
+ * Variable inner text is capture group 1; Liquid tag inner text is group 2.
+ */
+function buildTokenRegex(engine: RenderEngine): RegExp {
+  return engine === "liquid"
+    ? new RegExp(`\\{\\{([^}]*)\\}\\}|${LIQUID_TAG_TOKEN_SOURCE}`, "g")
+    : /\{\{([^}]*)\}\}/g;
+}
 
 const textStyleToHeadingLevel: Record<string, number> = { h1: 1, h2: 2, h3: 3, subtext: 3 };
 
@@ -25,15 +39,16 @@ const elementalAlignToTiptap = (align: string | undefined): string => {
  * formatting flags) into TipTap nodes. Handles variables ({{var}}) and newlines (\n → hardBreak).
  */
 export function convertElementsArrayToTiptapNodes(
-  elements: ElementalTextContentNode[]
+  elements: ElementalTextContentNode[],
+  engine: RenderEngine = "handlebars"
 ): TiptapNode[] {
   const nodes: TiptapNode[] = [];
 
   for (const el of elements) {
     if (el.type === "string") {
-      convertStringElementToTiptapNodes(el, nodes);
+      convertStringElementToTiptapNodes(el, nodes, engine);
     } else if (el.type === "link") {
-      convertLinkElementToTiptapNodes(el, nodes);
+      convertLinkElementToTiptapNodes(el, nodes, engine);
     }
     // "img" type can be added later if needed
   }
@@ -55,7 +70,8 @@ function buildMarksFromFlags(el: ElementalTextContentNode): TiptapMark[] {
 /** Convert an ElementalStringTextContent to TipTap nodes, handling \n and {{variables}}. */
 function convertStringElementToTiptapNodes(
   el: ElementalTextContentNode,
-  nodes: TiptapNode[]
+  nodes: TiptapNode[],
+  engine: RenderEngine = "handlebars"
 ): void {
   const content = "content" in el ? el.content : "";
   if (!content) return;
@@ -68,7 +84,7 @@ function convertStringElementToTiptapNodes(
     const line = lines[i];
     if (line) {
       // Parse variables within the line text
-      parseTextSegmentWithVariables(line, marks, nodes);
+      parseTextSegmentWithVariables(line, marks, nodes, engine);
     }
 
     // Add hardBreak between lines (not after the last one)
@@ -79,7 +95,11 @@ function convertStringElementToTiptapNodes(
 }
 
 /** Convert an ElementalLinkTextContent to TipTap nodes with a link mark. */
-function convertLinkElementToTiptapNodes(el: ElementalTextContentNode, nodes: TiptapNode[]): void {
+function convertLinkElementToTiptapNodes(
+  el: ElementalTextContentNode,
+  nodes: TiptapNode[],
+  engine: RenderEngine = "handlebars"
+): void {
   if (el.type !== "link") return;
   const content = el.content || "";
   if (!content) return;
@@ -88,7 +108,7 @@ function convertLinkElementToTiptapNodes(el: ElementalTextContentNode, nodes: Ti
   marks.push({ type: "link", attrs: { href: el.href } });
 
   // Parse variables within link text
-  parseTextSegmentWithVariables(content, marks, nodes);
+  parseTextSegmentWithVariables(content, marks, nodes, engine);
 }
 
 /**
@@ -98,17 +118,19 @@ function convertLinkElementToTiptapNodes(el: ElementalTextContentNode, nodes: Ti
 function parseTextSegmentWithVariables(
   text: string,
   marks: TiptapMark[],
-  nodes: TiptapNode[]
+  nodes: TiptapNode[],
+  engine: RenderEngine = "handlebars"
 ): void {
   if (!text) return;
 
-  const variableRegex = /\{\{([^}]*)\}\}/g;
+  // `{{ variable }}` (group 1); `{% liquid tag %}` (group 2) only under Liquid.
+  const tokenRegex = buildTokenRegex(engine);
   let match;
   let lastIndex = 0;
-  variableRegex.lastIndex = 0;
+  tokenRegex.lastIndex = 0;
 
-  while ((match = variableRegex.exec(text)) !== null) {
-    // Add text before the variable
+  while ((match = tokenRegex.exec(text)) !== null) {
+    // Add text before the token
     if (match.index > lastIndex) {
       const beforeText = text.substring(lastIndex, match.index);
       if (beforeText) {
@@ -120,24 +142,33 @@ function parseTextSegmentWithVariables(
       }
     }
 
-    // Add variable node
-    const variableName = match[1].trim();
-    const isValid = variableName === "" || isValidVariableName(variableName);
-    const hasLinkMark = marks.some((m) => m.type === "link");
-    nodes.push({
-      type: "variable",
-      attrs: {
-        id: variableName,
-        isInvalid: !isValid,
-        ...(hasLinkMark && { inUrlContext: true }),
-      },
-      ...(marks.length > 0 && { marks: [...marks] }),
-    });
+    if (match[1] !== undefined) {
+      // Variable node
+      const variableName = match[1].trim();
+      const isValid = variableName === "" || isValidVariableName(variableName, engine);
+      const hasLinkMark = marks.some((m) => m.type === "link");
+      nodes.push({
+        type: "variable",
+        attrs: {
+          id: variableName,
+          isInvalid: !isValid,
+          ...(hasLinkMark && { inUrlContext: true }),
+        },
+        ...(marks.length > 0 && { marks: [...marks] }),
+      });
+    } else {
+      // Liquid tag node ({% ... %}) — verbatim, no validation
+      nodes.push({
+        type: "liquidTag",
+        attrs: { content: (match[2] ?? "").trim() },
+        ...(marks.length > 0 && { marks: [...marks] }),
+      });
+    }
 
     lastIndex = match.index + match[0].length;
   }
 
-  // Add any remaining text after the last variable
+  // Add any remaining text after the last token
   if (lastIndex < text.length) {
     const remainingText = text.substring(lastIndex);
     if (remainingText) {
@@ -150,12 +181,12 @@ function parseTextSegmentWithVariables(
   }
 }
 
-export function parseMDContent(content: string): TiptapNode[] {
+export function parseMDContent(content: string, engine: RenderEngine = "handlebars"): TiptapNode[] {
   const nodes: TiptapNode[] = [];
   const textNodes = content.replace(/\n$/, "").split("\n");
 
   for (let i = 0; i < textNodes.length; i++) {
-    parseTextLine(textNodes[i], nodes);
+    parseTextLine(textNodes[i], nodes, engine);
 
     // Add hardBreak if not the last node
     if (i < textNodes.length - 1) {
@@ -167,14 +198,18 @@ export function parseMDContent(content: string): TiptapNode[] {
 }
 
 // Helper function to parse text line with variables
-function parseTextLine(line: string, nodes: TiptapNode[]): void {
+function parseTextLine(line: string, nodes: TiptapNode[], engine: RenderEngine): void {
   // Process markdown formatting
-  processMarkdownFormatting(line, nodes);
+  processMarkdownFormatting(line, nodes, engine);
 }
 
 // Process markdown formatting using complete pattern matching
 // This approach matches complete markdown patterns (e.g., *text*) rather than individual markers
-function processMarkdownFormatting(text: string, nodes: TiptapNode[]): void {
+function processMarkdownFormatting(
+  text: string,
+  nodes: TiptapNode[],
+  engine: RenderEngine = "handlebars"
+): void {
   if (!text) return;
 
   // Use a single regex to match all formatted patterns and variables
@@ -184,6 +219,10 @@ function processMarkdownFormatting(text: string, nodes: TiptapNode[]): void {
     // Variables: {{variable}} or {}variable{}
     { regex: /\{\{([^}]*)\}\}/g, type: "variable" },
     { regex: /\{\}([^{}]+)\{\}/g, type: "variable" },
+    // Liquid tags: {% ... %} — only recognized under the Liquid engine.
+    ...(engine === "liquid"
+      ? [{ regex: new RegExp(LIQUID_TAG_TOKEN_SOURCE, "g"), type: "liquidTag" }]
+      : []),
     // Links: [text](url)
     { regex: /\[([^\]]+)\]\(([^)]+)\)/g, type: "link" },
     // Bold: **text** or __text__
@@ -202,9 +241,9 @@ function processMarkdownFormatting(text: string, nodes: TiptapNode[]): void {
     start: number;
     end: number;
     text: string;
-    type: "plain" | "bold" | "italic" | "strike" | "underline" | "link" | "variable";
+    type: "plain" | "bold" | "italic" | "strike" | "underline" | "link" | "variable" | "liquidTag";
     marks?: string[];
-    attrs?: { href?: string; id?: string; isInvalid?: boolean };
+    attrs?: { href?: string; id?: string; isInvalid?: boolean; content?: string };
   }
 
   // Find all matches from all patterns
@@ -219,13 +258,21 @@ function processMarkdownFormatting(text: string, nodes: TiptapNode[]): void {
         // For empty variables (newly inserted, being edited), don't mark as invalid
         // Validation will happen on blur in VariableChipBase
         // Only validate non-empty variable names
-        const isValid = variableName === "" || isValidVariableName(variableName);
+        const isValid = variableName === "" || isValidVariableName(variableName, engine);
         allMatches.push({
           start: match.index,
           end: match.index + match[0].length,
           text: match[1],
           type: "variable",
           attrs: { id: variableName, isInvalid: !isValid },
+        });
+      } else if (pattern.type === "liquidTag") {
+        allMatches.push({
+          start: match.index,
+          end: match.index + match[0].length,
+          text: match[1],
+          type: "liquidTag",
+          attrs: { content: match[1].trim() },
         });
       } else if (pattern.type === "link") {
         allMatches.push({
@@ -268,7 +315,7 @@ function processMarkdownFormatting(text: string, nodes: TiptapNode[]): void {
     if (match.start > currentPos) {
       const plainText = text.substring(currentPos, match.start);
       if (plainText) {
-        parseTextWithVariables(plainText, [], finalNodes);
+        parseTextWithVariables(plainText, [], finalNodes, engine);
       }
     }
 
@@ -278,10 +325,15 @@ function processMarkdownFormatting(text: string, nodes: TiptapNode[]): void {
         type: "variable",
         attrs: { id: match.attrs?.id, isInvalid: match.attrs?.isInvalid },
       });
+    } else if (match.type === "liquidTag") {
+      finalNodes.push({
+        type: "liquidTag",
+        attrs: { content: match.attrs?.content ?? "" },
+      });
     } else if (match.type === "link") {
       const linkNodes: TiptapNode[] = [];
       // Recursively process the link text for nested formatting
-      processMarkdownFormatting(match.text, linkNodes);
+      processMarkdownFormatting(match.text, linkNodes, engine);
       linkNodes.forEach((node) => {
         node.marks = node.marks || [];
         node.marks.push({
@@ -294,7 +346,7 @@ function processMarkdownFormatting(text: string, nodes: TiptapNode[]): void {
       // Bold, italic, strike, underline
       const formattedNodes: TiptapNode[] = [];
       // Recursively process for nested formatting
-      processMarkdownFormatting(match.text, formattedNodes);
+      processMarkdownFormatting(match.text, formattedNodes, engine);
       // Apply the mark to all nodes
       formattedNodes.forEach((node) => {
         node.marks = node.marks || [];
@@ -310,7 +362,7 @@ function processMarkdownFormatting(text: string, nodes: TiptapNode[]): void {
   if (currentPos < text.length) {
     const remainingText = text.substring(currentPos);
     if (remainingText) {
-      parseTextWithVariables(remainingText, [], finalNodes);
+      parseTextWithVariables(remainingText, [], finalNodes, engine);
     }
   }
 
@@ -323,27 +375,19 @@ function processMarkdownFormatting(text: string, nodes: TiptapNode[]): void {
 function parseTextWithVariables(
   text: string,
   marks: { text: string; href?: string; type: string }[],
-  nodes: TiptapNode[]
+  nodes: TiptapNode[],
+  engine: RenderEngine = "handlebars"
 ): void {
   if (!text) return; // Skip empty text
 
-  // Use a more robust regex that ensures we match complete {{variable}} patterns
-  // The pattern matches {{ followed by one or more non-} characters, then }}
-  const variableRegex = /\{\{([^}]*)\}\}/g;
+  // `{{ variable }}` (group 1); `{% liquid tag %}` (group 2) only under Liquid.
+  const tokenRegex = buildTokenRegex(engine);
   let match;
   let lastIndex = 0;
+  tokenRegex.lastIndex = 0;
 
-  // Reset regex lastIndex to ensure clean matching
-  variableRegex.lastIndex = 0;
-
-  while ((match = variableRegex.exec(text)) !== null) {
-    // Ensure we have a complete match with both opening and closing braces
-    if (!match[0].startsWith("{{") || !match[0].endsWith("}}")) {
-      // Skip incomplete matches
-      continue;
-    }
-
-    // Add text before the variable if it exists
+  while ((match = tokenRegex.exec(text)) !== null) {
+    // Add text before the token if it exists
     if (match.index > lastIndex) {
       const beforeText = text.substring(lastIndex, match.index);
       if (beforeText) {
@@ -355,30 +399,33 @@ function parseTextWithVariables(
       }
     }
 
-    // Extract variable name (match[1] contains the captured group)
-    const variableName = match[1].trim();
-
-    // Check if this variable is inside a link
-    const hasLinkMark = marks.some((mark) => mark.type === "link");
-
-    // For empty variables (newly inserted, being edited), don't mark as invalid
-    // Validation will happen on blur in VariableChipBase
-    // Only validate non-empty variable names
-    const isValid = variableName === "" || isValidVariableName(variableName);
-    nodes.push({
-      type: "variable",
-      attrs: {
-        id: variableName,
-        isInvalid: !isValid,
-        ...(hasLinkMark && { inUrlContext: true }),
-      },
-      ...(marks.length > 0 && { marks }),
-    });
+    if (match[1] !== undefined) {
+      // Variable node
+      const variableName = match[1].trim();
+      const hasLinkMark = marks.some((mark) => mark.type === "link");
+      const isValid = variableName === "" || isValidVariableName(variableName, engine);
+      nodes.push({
+        type: "variable",
+        attrs: {
+          id: variableName,
+          isInvalid: !isValid,
+          ...(hasLinkMark && { inUrlContext: true }),
+        },
+        ...(marks.length > 0 && { marks }),
+      });
+    } else {
+      // Liquid tag node ({% ... %})
+      nodes.push({
+        type: "liquidTag",
+        attrs: { content: (match[2] ?? "").trim() },
+        ...(marks.length > 0 && { marks }),
+      });
+    }
 
     lastIndex = match.index + match[0].length;
   }
 
-  // Add any remaining text after the last variable (or the entire text if no variables were found)
+  // Add any remaining text after the last token (or the entire text if none were found)
   if (lastIndex < text.length) {
     const remainingText = text.substring(lastIndex);
     if (remainingText) {
@@ -393,6 +440,12 @@ function parseTextWithVariables(
 
 export interface ConvertElementalToTiptapOptions {
   channel?: string; // e.g., 'email', 'sms'
+  /**
+   * Rendering engine for token parsing. Defaults to the content's
+   * `render_options.engine`, then Handlebars. Only under Liquid is `{% %}`
+   * parsed into tag chips.
+   */
+  renderEngine?: RenderEngine;
 }
 
 export function convertElementalToTiptap(
@@ -404,6 +457,10 @@ export function convertElementalToTiptap(
   if (!elemental || !elemental.elements || elemental.elements.length === 0) {
     return emptyTiptapDoc;
   }
+
+  // Engine drives token parsing: `{% %}` becomes a tag chip only under Liquid.
+  const engine: RenderEngine =
+    options?.renderEngine ?? elemental.render_options?.engine ?? "handlebars";
 
   let targetChannelElements: ElementalNode[] | undefined = undefined;
   const specifiedChannelName = options?.channel;
@@ -523,7 +580,7 @@ export function convertElementalToTiptap(
           }
 
           // Handle empty content - ensure it becomes an empty paragraph
-          const contentNodes = node.content.trim() ? parseMDContent(node.content) : [];
+          const contentNodes = node.content.trim() ? parseMDContent(node.content, engine) : [];
 
           return [
             {
@@ -572,7 +629,7 @@ export function convertElementalToTiptap(
             };
           }
 
-          const contentNodes = convertElementsArrayToTiptapNodes(node.elements);
+          const contentNodes = convertElementsArrayToTiptapNodes(node.elements, engine);
 
           return [
             {
@@ -614,7 +671,7 @@ export function convertElementalToTiptap(
 
         // Parse content to extract variables and create proper TipTap nodes
         const contentNodes: TiptapNode[] = [];
-        parseTextWithVariables(contentText, [], contentNodes);
+        parseTextWithVariables(contentText, [], contentNodes, engine);
 
         // If no nodes were created (empty content), create a default text node
         if (contentNodes.length === 0) {
@@ -700,7 +757,7 @@ export function convertElementalToTiptap(
                 {
                   type: "paragraph",
                   attrs: { id: `node-${uuidv4()}` },
-                  content: parseMDContent(textContent),
+                  content: parseMDContent(textContent, engine),
                 },
               ],
             });
@@ -757,7 +814,7 @@ export function convertElementalToTiptap(
             {
               type: childType,
               attrs: childAttrs,
-              content: parseMDContent(node.content),
+              content: parseMDContent(node.content, engine),
             },
           ];
         }
@@ -1301,7 +1358,7 @@ export function convertElementalToTiptap(
                     content.push({
                       type: "paragraph",
                       attrs: { textAlign: "left", id: `node-${uuidv4()}` },
-                      content: convertElementsArrayToTiptapNodes(pendingInline),
+                      content: convertElementsArrayToTiptapNodes(pendingInline, engine),
                     });
                     pendingInline = [];
                   }
@@ -1329,7 +1386,7 @@ export function convertElementalToTiptap(
                   {
                     type: "paragraph",
                     attrs: { textAlign: "left", id: `node-${uuidv4()}` },
-                    content: parseMDContent(listItem.content),
+                    content: parseMDContent(listItem.content, engine),
                   },
                 ];
               }

--- a/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.test.tsx
+++ b/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.test.tsx
@@ -39,6 +39,24 @@ describe("convertTiptapToElemental", () => {
     ]);
   });
 
+  it("should serialize a liquidTag node to {% %} syntax", () => {
+    const tiptap = createTiptapDoc([
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "Hi " },
+          { type: "liquidTag", attrs: { content: "if data.vip" } },
+          { type: "text", text: "!" },
+        ],
+      },
+    ]);
+
+    const result = convertTiptapToElemental(tiptap);
+    const element = result[0] as { elements: { type: string; content: string }[] };
+
+    expect(element.elements).toContainEqual({ type: "string", content: "{% if data.vip %}" });
+  });
+
   it("should convert paragraph with text alignment", () => {
     const tiptap = createTiptapDoc([
       {
@@ -2564,9 +2582,7 @@ describe("convertTiptapToElemental", () => {
               },
             },
           },
-          content: [
-            { type: "text", text: "Hello world" },
-          ],
+          content: [{ type: "text", text: "Hello world" }],
         },
       ]);
 
@@ -2597,9 +2613,7 @@ describe("convertTiptapToElemental", () => {
               },
             },
           },
-          content: [
-            { type: "text", text: "Hello world" },
-          ],
+          content: [{ type: "text", text: "Hello world" }],
         },
       ]);
 
@@ -2662,15 +2676,11 @@ describe("convertTiptapToElemental", () => {
             level: 2,
             locales: {
               de: {
-                elements: [
-                  { type: "string", content: "Willkommen", bold: true },
-                ],
+                elements: [{ type: "string", content: "Willkommen", bold: true }],
               },
             },
           },
-          content: [
-            { type: "text", text: "Welcome", marks: [{ type: "bold" }] },
-          ],
+          content: [{ type: "text", text: "Welcome", marks: [{ type: "bold" }] }],
         },
       ]);
 
@@ -2678,9 +2688,7 @@ describe("convertTiptapToElemental", () => {
 
       expect((result[0] as any).locales).toEqual({
         de: {
-          elements: [
-            { type: "string", content: "Willkommen", bold: true },
-          ],
+          elements: [{ type: "string", content: "Willkommen", bold: true }],
         },
       });
     });
@@ -3162,10 +3170,7 @@ describe("convertTiptapToElemental", () => {
             {
               type: "text",
               text: "Click here",
-              marks: [
-                { type: "bold" },
-                { type: "link", attrs: { href: "https://example.com" } },
-              ],
+              marks: [{ type: "bold" }, { type: "link", attrs: { href: "https://example.com" } }],
             },
           ],
         },
@@ -3209,9 +3214,7 @@ describe("convertTiptapToElemental", () => {
         {
           type: "text",
           align: "left",
-          elements: [
-            { type: "string", content: "red text", color: "#ff0000" },
-          ],
+          elements: [{ type: "string", content: "red text", color: "#ff0000" }],
         },
       ]);
     });
@@ -3224,10 +3227,7 @@ describe("convertTiptapToElemental", () => {
             {
               type: "text",
               text: "bold red",
-              marks: [
-                { type: "bold" },
-                { type: "textStyle", attrs: { color: "#ff0000" } },
-              ],
+              marks: [{ type: "bold" }, { type: "textStyle", attrs: { color: "#ff0000" } }],
             },
           ],
         },
@@ -3239,9 +3239,7 @@ describe("convertTiptapToElemental", () => {
         {
           type: "text",
           align: "left",
-          elements: [
-            { type: "string", content: "bold red", bold: true, color: "#ff0000" },
-          ],
+          elements: [{ type: "string", content: "bold red", bold: true, color: "#ff0000" }],
         },
       ]);
     });
@@ -3300,9 +3298,7 @@ describe("convertTiptapToElemental", () => {
         {
           type: "text",
           align: "left",
-          elements: [
-            { type: "string", content: "before\n\n\nafter" },
-          ],
+          elements: [{ type: "string", content: "before\n\n\nafter" }],
         },
       ]);
     });
@@ -3346,9 +3342,7 @@ describe("convertTiptapToElemental", () => {
       const tiptap = createTiptapDoc([
         {
           type: "paragraph",
-          content: [
-            { type: "text", text: "plain text" },
-          ],
+          content: [{ type: "text", text: "plain text" }],
         },
       ]);
 
@@ -3358,9 +3352,7 @@ describe("convertTiptapToElemental", () => {
         {
           type: "text",
           align: "left",
-          elements: [
-            { type: "string", content: "plain text" },
-          ],
+          elements: [{ type: "string", content: "plain text" }],
         },
       ]);
       expect(result[0]).not.toHaveProperty("color");
@@ -3421,9 +3413,7 @@ describe("convertTiptapToElemental", () => {
           type: "text",
           text_style: "h1",
           align: "left",
-          elements: [
-            { type: "string", content: "colored heading", color: "#0000ff" },
-          ],
+          elements: [{ type: "string", content: "colored heading", color: "#0000ff" }],
         },
       ]);
     });
@@ -3520,9 +3510,7 @@ describe("convertTiptapToElemental", () => {
         {
           type: "text",
           align: "left",
-          elements: [
-            { type: "string", content: "brand colored", color: "{brand.colors.primary}" },
-          ],
+          elements: [{ type: "string", content: "brand colored", color: "{brand.colors.primary}" }],
         },
       ]);
     });
@@ -3684,10 +3672,7 @@ describe("convertTiptapToElemental", () => {
       const tiptap = createTiptapDoc([
         {
           type: "paragraph",
-          content: [
-            { type: "hardBreak" },
-            { type: "text", text: "after break" },
-          ],
+          content: [{ type: "hardBreak" }, { type: "text", text: "after break" }],
         },
       ]);
 
@@ -3698,9 +3683,7 @@ describe("convertTiptapToElemental", () => {
         {
           type: "text",
           align: "left",
-          elements: [
-            { type: "string", content: "\nafter break" },
-          ],
+          elements: [{ type: "string", content: "\nafter break" }],
         },
       ]);
     });
@@ -3710,9 +3693,7 @@ describe("convertTiptapToElemental", () => {
         {
           type: "heading",
           attrs: { level: 1 },
-          content: [
-            { type: "text", text: "Bold heading", marks: [{ type: "bold" }] },
-          ],
+          content: [{ type: "text", text: "Bold heading", marks: [{ type: "bold" }] }],
         },
       ]);
 
@@ -3722,9 +3703,7 @@ describe("convertTiptapToElemental", () => {
         {
           type: "text",
           align: "left",
-          elements: [
-            { type: "string", content: "Bold heading", bold: true },
-          ],
+          elements: [{ type: "string", content: "Bold heading", bold: true }],
           text_style: "h1",
         },
       ]);
@@ -3759,9 +3738,7 @@ describe("convertTiptapToElemental", () => {
       expect(textNode.locales.de._sourceHash).toBe("abc123");
       expect(textNode.locales.de.elements).toBeDefined();
       expect(textNode.locales.fr._sourceHash).toBe("xyz789");
-      expect(textNode.locales.fr.elements).toEqual([
-        { type: "string", content: "Bonjour" },
-      ]);
+      expect(textNode.locales.fr.elements).toEqual([{ type: "string", content: "Bonjour" }]);
     });
 
     it("should preserve extra properties alongside elements on locale entries", () => {
@@ -3786,9 +3763,7 @@ describe("convertTiptapToElemental", () => {
 
       expect(textNode.locales.de._sourceHash).toBe("hash1");
       expect(textNode.locales.de._customMeta).toBe("preserved");
-      expect(textNode.locales.de.elements).toEqual([
-        { type: "string", content: "Hallo" },
-      ]);
+      expect(textNode.locales.de.elements).toEqual([{ type: "string", content: "Hallo" }]);
     });
   });
 });

--- a/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts
+++ b/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts
@@ -59,6 +59,10 @@ const convertTextToMarkdown = (node: TiptapNode): string => {
     return `{{${node.attrs?.id}}}`;
   }
 
+  if (node.type === "liquidTag") {
+    return `{% ${node.attrs?.content ?? ""} %}`;
+  }
+
   let text = node.text || "";
 
   if (node.marks?.length) {
@@ -165,6 +169,17 @@ const convertTiptapNodesToElements = (nodes: TiptapNode[]): ElementalTextContent
       elements.push({
         type: "string",
         content: `{{${node.attrs?.id}}}`,
+        ...flags,
+      });
+      continue;
+    }
+
+    if (node.type === "liquidTag") {
+      flush();
+      const flags = getFormattingFlags(node.marks);
+      elements.push({
+        type: "string",
+        content: `{% ${node.attrs?.content ?? ""} %}`,
         ...flags,
       });
       continue;

--- a/packages/react-designer/src/lib/utils/liquidTagToken.ts
+++ b/packages/react-designer/src/lib/utils/liquidTagToken.ts
@@ -1,0 +1,10 @@
+/**
+ * Regex source for a whole Liquid `{% ... %}` tag, capturing the inner text in
+ * one group. The inner matcher is quote-aware: a `%}` that appears inside a
+ * single- or double-quoted argument (e.g. `{% assign x = s | split: '%}' %}`)
+ * is consumed as part of the quoted string and does not end the tag.
+ *
+ * Inner = any run of: a char that is not `%`/quote, OR a `%` not followed by `}`,
+ * OR a single-quoted string, OR a double-quoted string.
+ */
+export const LIQUID_TAG_TOKEN_SOURCE = "\\{%((?:[^%'\"]|%(?!\\})|'[^']*'|\"[^\"]*\")*)%\\}";

--- a/packages/react-designer/src/lib/utils/normalizeVariableSpacing.test.ts
+++ b/packages/react-designer/src/lib/utils/normalizeVariableSpacing.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { normalizeVariableSpacing } from "./normalizeVariableSpacing";
+
+describe("normalizeVariableSpacing", () => {
+  describe("liquid", () => {
+    it("adds inner spaces to variable tokens", () => {
+      expect(normalizeVariableSpacing("Hello {{data.name}}", "liquid")).toBe(
+        "Hello {{ data.name }}"
+      );
+    });
+
+    it("normalizes existing/irregular spacing", () => {
+      expect(normalizeVariableSpacing("{{  data.name  }}", "liquid")).toBe("{{ data.name }}");
+      expect(normalizeVariableSpacing("{{ data.name}}", "liquid")).toBe("{{ data.name }}");
+    });
+
+    it("preserves filters while spacing the token", () => {
+      expect(normalizeVariableSpacing("{{data.name | upcase}}", "liquid")).toBe(
+        "{{ data.name | upcase }}"
+      );
+    });
+
+    it("handles multiple tokens in one string", () => {
+      expect(normalizeVariableSpacing("{{data.a}} and {{data.b}}", "liquid")).toBe(
+        "{{ data.a }} and {{ data.b }}"
+      );
+    });
+
+    it("normalizes {% %} tag spacing", () => {
+      expect(normalizeVariableSpacing("{%if data.vip%}", "liquid")).toBe("{% if data.vip %}");
+      expect(normalizeVariableSpacing("{%  endif  %}", "liquid")).toBe("{% endif %}");
+    });
+
+    it("handles mixed {{ }} and {% %} tokens", () => {
+      expect(normalizeVariableSpacing("{%if data.vip%}{{data.name}}", "liquid")).toBe(
+        "{% if data.vip %}{{ data.name }}"
+      );
+    });
+
+    it("does not truncate a tag whose quoted arg contains %}", () => {
+      // The inner '%}' must be treated as a string literal, not the tag close.
+      expect(normalizeVariableSpacing("{%assign x = data.s | split: '%}'%}", "liquid")).toBe(
+        "{% assign x = data.s | split: '%}' %}"
+      );
+    });
+  });
+
+  describe("handlebars (no-op)", () => {
+    it("leaves spaced variable tokens untouched (no unsolicited mutation)", () => {
+      expect(normalizeVariableSpacing("Hello {{ data.name }}", "handlebars")).toBe(
+        "Hello {{ data.name }}"
+      );
+    });
+
+    it("leaves tight tokens unchanged", () => {
+      expect(normalizeVariableSpacing("{{data.name}}", "handlebars")).toBe("{{data.name}}");
+    });
+
+    it("does not touch triple-stache raw output", () => {
+      expect(normalizeVariableSpacing("{{{ rawHtml }}}", "handlebars")).toBe("{{{ rawHtml }}}");
+    });
+
+    it("leaves {% %} tags untouched", () => {
+      expect(normalizeVariableSpacing("{% if x %}", "handlebars")).toBe("{% if x %}");
+    });
+  });
+
+  it("recurses through nested elemental content", () => {
+    const content = {
+      version: "2022-01-01" as const,
+      elements: [
+        {
+          type: "text",
+          content: "Hi {{data.first}}",
+          elements: [{ type: "string", content: "{{data.nested}}" }],
+        },
+      ],
+    };
+
+    const result = normalizeVariableSpacing(content, "liquid");
+
+    expect(result.elements[0].content).toBe("Hi {{ data.first }}");
+    // @ts-expect-error nested test shape
+    expect(result.elements[0].elements[0].content).toBe("{{ data.nested }}");
+    // Does not mutate the input.
+    expect(content.elements[0].content).toBe("Hi {{data.first}}");
+  });
+
+  it("leaves strings without variables untouched", () => {
+    expect(normalizeVariableSpacing("#ffffff", "liquid")).toBe("#ffffff");
+    expect(normalizeVariableSpacing("plain text", "liquid")).toBe("plain text");
+  });
+});

--- a/packages/react-designer/src/lib/utils/normalizeVariableSpacing.ts
+++ b/packages/react-designer/src/lib/utils/normalizeVariableSpacing.ts
@@ -1,0 +1,59 @@
+import type { RenderEngine } from "@/types";
+import { LIQUID_TAG_TOKEN_SOURCE } from "./liquidTagToken";
+
+// Matches a whole `{{ ... }}` variable token. The inner group excludes `}` so
+// it never spans across two adjacent tokens.
+const VARIABLE_TOKEN_REGEX = /\{\{\s*([^}]*?)\s*\}\}/g;
+
+// Quote-aware `{% ... %}` tag matcher (shared with the parser).
+const TAG_TOKEN_REGEX = new RegExp(LIQUID_TAG_TOKEN_SOURCE, "g");
+
+/** Rewrite a single string's `{{ }}`/`{% %}` tokens to Liquid's spaced form. */
+function rewriteString(value: string): string {
+  let result = value;
+
+  if (result.includes("{{")) {
+    result = result.replace(
+      VARIABLE_TOKEN_REGEX,
+      (_match, inner: string) => `{{ ${inner.trim()} }}`
+    );
+  }
+
+  if (result.includes("{%")) {
+    result = result.replace(TAG_TOKEN_REGEX, (_match, inner: string) => `{% ${inner.trim()} %}`);
+  }
+
+  return result;
+}
+
+/**
+ * Recursively normalizes variable/tag token spacing to Liquid's `{{ x }}` /
+ * `{% x %}` form across every string in a value.
+ *
+ * This is a **no-op for non-Liquid engines** — Handlebars content is returned
+ * untouched so externally/API-authored templates aren't silently rewritten on
+ * save (and the whole tree walk is skipped).
+ */
+export function normalizeVariableSpacing<T>(value: T, engine: RenderEngine): T {
+  if (engine !== "liquid") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return rewriteString(value) as unknown as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeVariableSpacing(item, engine)) as unknown as T;
+  }
+
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      result[key] = normalizeVariableSpacing(val, engine);
+    }
+    return result as T;
+  }
+
+  return value;
+}

--- a/packages/react-designer/src/styles.css
+++ b/packages/react-designer/src/styles.css
@@ -1676,6 +1676,17 @@
   }
 }
 
+/* Liquid `{% %}` tag chip - distinct violet palette to read as logic, not content.
+   Shares the base layout from .courier-variable-chip; these rules override color. */
+.courier-liquid-tag-chip {
+  color: #6d28d9;
+
+  &:before {
+    background-color: #f5f3ff;
+    border-color: #ddd6fe;
+  }
+}
+
 /* Variable Textarea placeholder styles */
 .variable-textarea-placeholder {
   @apply courier-cursor-text;

--- a/packages/react-designer/src/types/elemental.schema.ts
+++ b/packages/react-designer/src/types/elemental.schema.ts
@@ -282,9 +282,15 @@ export const ElementalNodeType = z.union([
   ListItemNode,
 ]) as z.ZodType<ElementalNode>;
 
+export const RenderOptionsSchema = z.object({
+  engine: z.enum(["handlebars", "liquid"]).optional(),
+  strict_variables: z.boolean().optional(),
+});
+
 export const ElementalSchema = z.object({
   version: z.literal("2022-01-01"),
   elements: z.array(ElementalNodeType),
+  render_options: RenderOptionsSchema.optional(),
 });
 
 export const validateElemental = (json: unknown) => {

--- a/packages/react-designer/src/types/elemental.types.ts
+++ b/packages/react-designer/src/types/elemental.types.ts
@@ -18,9 +18,24 @@ export interface BorderConfig {
   size?: string;
 }
 
+/** Template rendering engine. Defaults to Handlebars when unspecified. */
+export type RenderEngine = "handlebars" | "liquid";
+
+/**
+ * Document-level rendering options that travel with the content.
+ * Mirrors the backend `render_options` field on `ElementalContent`.
+ */
+export interface ElementalRenderOptions {
+  /** Which template engine renders variable interpolation. Default: "handlebars". */
+  engine?: RenderEngine;
+  /** Liquid-only. Fail rendering on missing variables. Default: false. */
+  strict_variables?: boolean;
+}
+
 export interface ElementalContent {
   version: "2022-01-01";
   elements: ElementalNode[];
+  render_options?: ElementalRenderOptions;
 }
 
 export type ElementalNode =


### PR DESCRIPTION
## What

Adds first-class editor support for the backend's opt-in **Liquid** rendering engine (`render_options.engine` on `ElementalContent`, from [trycourier/backend#9690](https://github.com/trycourier/backend/pull/9690) / C-19012). Handlebars stays the default and is unchanged.

Linear: [C-19022](https://linear.app/trycourier/issue/C-19022)

## Changes

**Engine selection & persistence**
- `render_options` on the `ElementalContent` type + zod schema; `RenderEngine` / `ElementalRenderOptions` exported.
- `renderEngineAtom` (default `handlebars`), injected into `render_options` at the save choke point (`applyRenderEngine`), hydrated from loaded content, reset on template switch.
- Controlled `renderEngine` prop on `TemplateEditor` (persists on change). The engine selector lives in the **`editor-dev` harness** (next to Tenant/Template), not the library UI.

**Liquid-aware `{{ }}` variables**
- Engine-aware `isValidVariableName(name, engine)`: Liquid accepts filters (`| upcase`, `| times: 1.1`), bracket indexing (`data.items[0]`, `data['key']`), and requires a known namespace root (`data`/`profile`/`brand`/`urls`); bare names are flagged.
- `data.`-namespaced autocomplete; chips re-validate per engine.
- Liquid spacing normalization at save (`{{ data.name }}`); Handlebars stays tight (`{{data.name}}`).

**Liquid `{% %}` tag chips**
- New `liquidTag` inline-atom node + NodeView — distinct violet chip with a `%` icon, reusing `VariableChipBase` via a new `freeform` mode (no autocomplete/validation).
- Parse `{% %}` → node and serialize node → `{% content %}` across the conversion pipeline; `{%` input rule gated to Liquid. **No validation** — chips are visual and round-trip verbatim.

**Editor UX**
- Enter on a selected variable/tag chip now drops into edit mode (node priority above Paragraph's line-break handler).

## Out of scope
- `{% %}` validation (balanced/known tags, argument grammar) — much larger lift; deliberately omitted.
- Block-spanning `{% for %}`/`{% if %}` execution (backend interpolates per field).
- Brand-footer markdown (`convertMarkdownToTiptap`) is not engine-aware.

## Testing
- New unit tests: `validateVariableName` (Liquid filters/brackets/namespace + Handlebars-unchanged), `normalizeVariableSpacing` (`{{ }}` & `{% %}`), `convertElementalToTiptap`/`convertTiptapToElemental` (`{% %}` parse/serialize), `LiquidTag` node (priority, Enter shortcut, input-rule gating), `VariableChipBase` (Enter-to-edit).
- Full suite green (**2758 passed**), typecheck + lint clean, package builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)