### PR TITLE
[C-19020] Add brand CSS targeting classes to designer components

### DIFF
--- a/packages/react-designer/src/components/extensions/Blockquote/Blockquote.ts
+++ b/packages/react-designer/src/components/extensions/Blockquote/Blockquote.ts
@@ -138,6 +138,7 @@ export const Blockquote = TiptapBlockquote.extend({
       mergeAttributes(HTMLAttributes, {
         "data-type": "blockquote",
         "data-id": HTMLAttributes.id,
+        class: "c--block c--block-quote c--text-quote",
       }),
       0,
     ];

--- a/packages/react-designer/src/components/extensions/Blockquote/BlockquoteComponent.tsx
+++ b/packages/react-designer/src/components/extensions/Blockquote/BlockquoteComponent.tsx
@@ -17,7 +17,7 @@ export const BlockquoteComponent: React.FC<BlockquoteProps> = ({
 }) => {
   const resolveColor = useBrandColorResolver();
   return (
-    <div className="courier-w-full courier-my-2 node-element">
+    <div className="courier-w-full courier-my-2 node-element c--block c--block-quote c--text-quote">
       <div
         style={{
           position: "relative",

--- a/packages/react-designer/src/components/extensions/Button/Button.ts
+++ b/packages/react-designer/src/components/extensions/Button/Button.ts
@@ -194,6 +194,7 @@ export const Button = Node.create({
       "div",
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
         "data-type": "button",
+        class: "c--block c--block-action",
       }),
       0,
     ];

--- a/packages/react-designer/src/components/extensions/Button/ButtonComponent.tsx
+++ b/packages/react-designer/src/components/extensions/Button/ButtonComponent.tsx
@@ -64,7 +64,7 @@ export const ButtonComponent: React.FC<
   // In preview mode with a link, wrap button in an anchor tag
   if (isPreviewMode && link) {
     return (
-      <div className="courier-w-full node-element">
+      <div className="courier-w-full node-element c--block c--block-action">
         <div className="courier-flex">
           <a
             href={link}
@@ -92,7 +92,7 @@ export const ButtonComponent: React.FC<
   }
 
   return (
-    <div className="courier-w-full node-element">
+    <div className="courier-w-full node-element c--block c--block-action">
       <div className="courier-flex">{buttonContent}</div>
     </div>
   );

--- a/packages/react-designer/src/components/extensions/Column/Column.ts
+++ b/packages/react-designer/src/components/extensions/Column/Column.ts
@@ -134,6 +134,7 @@ export const Column = Node.create({
       "div",
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
         "data-type": "column",
+        class: "c--block c--block-columns",
       }),
       0,
     ];

--- a/packages/react-designer/src/components/extensions/Column/ColumnComponent.tsx
+++ b/packages/react-designer/src/components/extensions/Column/ColumnComponent.tsx
@@ -106,7 +106,7 @@ export const ColumnComponent: React.FC<
     const columnId = node.attrs?.id || "";
 
     return (
-      <div className="courier-w-full node-element" style={containerStyle}>
+      <div className="courier-w-full node-element c--block c--block-columns" style={containerStyle}>
         {/* Inner container for flex layout with gap - use gap-4 (16px) to match actual column row */}
         <div className="courier-w-full courier-flex courier-gap-4">
           {Array.from({ length: columnsCount }).map((_, index) => (
@@ -123,7 +123,7 @@ export const ColumnComponent: React.FC<
   }
 
   return (
-    <div className="courier-w-full node-element" style={containerStyle}>
+    <div className="courier-w-full node-element c--block c--block-columns" style={containerStyle}>
       {/* Inner container for clickable area around cells */}
       <div className="courier-w-full">
         <NodeViewContent />

--- a/packages/react-designer/src/components/extensions/Divider/Divider.ts
+++ b/packages/react-designer/src/components/extensions/Divider/Divider.ts
@@ -109,6 +109,7 @@ export const Divider = TiptapHorizontalRule.extend({
       "div",
       mergeAttributes(HTMLAttributes, {
         "data-type": "divider",
+        class: "c--block c--block-divider",
       }),
       ["hr"],
     ];

--- a/packages/react-designer/src/components/extensions/Divider/DividerComponent.tsx
+++ b/packages/react-designer/src/components/extensions/Divider/DividerComponent.tsx
@@ -17,7 +17,7 @@ export const DividerComponent: React.FC<
 > = ({ padding, color, size, radius, variant = "divider" }) => {
   const resolveColor = useBrandColorResolver();
   return (
-    <div className="courier-w-full node-element courier-flex">
+    <div className="courier-w-full node-element courier-flex c--block c--block-divider">
       <hr
         style={{
           marginTop: `${padding}px`,

--- a/packages/react-designer/src/components/extensions/Heading/Heading.ts
+++ b/packages/react-designer/src/components/extensions/Heading/Heading.ts
@@ -135,7 +135,13 @@ export const Heading = TiptapHeading.extend({
     const hasLevel = this.options.levels.includes(nodeLevel);
     const level = hasLevel ? nodeLevel : this.options.levels[0];
 
-    return [`h${level}`, mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0];
+    return [
+      `h${level}`,
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        class: `c--block c--block-text c--text-h${level}`,
+      }),
+      0,
+    ];
   },
 
   addNodeView() {

--- a/packages/react-designer/src/components/extensions/ImageBlock/ImageBlock.ts
+++ b/packages/react-designer/src/components/extensions/ImageBlock/ImageBlock.ts
@@ -140,6 +140,7 @@ export const ImageBlock = Node.create({
       "div",
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
         "data-type": "image-block",
+        class: "c--block c--block-image",
       }),
       0,
     ];

--- a/packages/react-designer/src/components/extensions/ImageBlock/components/ImageBlockView.tsx
+++ b/packages/react-designer/src/components/extensions/ImageBlock/components/ImageBlockView.tsx
@@ -161,7 +161,7 @@ export const ImageBlockComponent: React.FC<
   }
 
   return (
-    <div className="courier-w-full node-element">
+    <div className="courier-w-full node-element c--block c--block-image">
       <div
         className={cn(
           "courier-relative courier-p-1",

--- a/packages/react-designer/src/components/extensions/List/List.ts
+++ b/packages/react-designer/src/components/extensions/List/List.ts
@@ -97,6 +97,7 @@ export const List = Node.create({
       tag,
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
         "data-type": "list",
+        class: "c--block c--block-list",
       }),
       0,
     ];

--- a/packages/react-designer/src/components/extensions/List/ListComponent.tsx
+++ b/packages/react-designer/src/components/extensions/List/ListComponent.tsx
@@ -70,7 +70,7 @@ export const ListComponentNode = (props: NodeViewProps) => {
   // If inside a blockquote, render a simple wrapper without drag/selection UI
   if (isInsideBlockquote) {
     return (
-      <NodeViewWrapper className="node-list">
+      <NodeViewWrapper className="node-list c--block c--block-list">
         <ListTag
           className={cn(
             "courier-list-wrapper",
@@ -96,7 +96,7 @@ export const ListComponentNode = (props: NodeViewProps) => {
       onClick={handleSelect}
       editor={props.editor}
     >
-      <div className="node-element">
+      <div className="node-element c--block c--block-list">
         <ListTag
           className={cn(
             "courier-list-wrapper",

--- a/packages/react-designer/src/components/extensions/Paragraph/Paragraph.ts
+++ b/packages/react-designer/src/components/extensions/Paragraph/Paragraph.ts
@@ -138,6 +138,7 @@ export const Paragraph = TiptapParagraph.extend({
       "div",
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
         "data-type": "paragraph",
+        class: "c--block c--block-text c--text-text",
       }),
       0,
     ];

--- a/packages/react-designer/src/components/extensions/TextBlock/TextBlockComponent.tsx
+++ b/packages/react-designer/src/components/extensions/TextBlock/TextBlockComponent.tsx
@@ -33,7 +33,9 @@ export const TextBlockComponent: React.FC<
   const resolveColor = useBrandColorResolver();
 
   return (
-    <div className="courier-w-full node-element">
+    <div
+      className={`courier-w-full node-element c--block c--block-text${type === "heading" ? ` c--text-h${level}` : " c--text-text"}`}
+    >
       <div
         style={{
           padding: `${paddingVertical}px ${paddingHorizontal}px`,

--- a/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
+++ b/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
@@ -667,7 +667,10 @@ export function convertElementalToTiptap(
 
       case "quote": {
         // Helper to detect if content is a markdown-style list
-        const isListContent = (content: string): { isList: boolean; isOrdered: boolean } => {
+        const isListContent = (
+          content: string | undefined
+        ): { isList: boolean; isOrdered: boolean } => {
+          if (!content) return { isList: false, isOrdered: false };
           const lines = content.split("\n").filter((l) => l.trim());
           if (lines.length === 0) return { isList: false, isOrdered: false };
 
@@ -719,14 +722,15 @@ export function convertElementalToTiptap(
         };
 
         // Check if content is a list
-        const listInfo = isListContent(node.content);
+        const quoteContent = node.content ?? "";
+        const listInfo = isListContent(quoteContent);
 
         // Build blockquote content
         let blockquoteContent: TiptapNode[];
 
         if (listInfo.isList) {
           // Content is a list - convert to list node
-          blockquoteContent = parseListContent(node.content, listInfo.isOrdered);
+          blockquoteContent = parseListContent(quoteContent, listInfo.isOrdered);
         } else {
           // Regular text content
           // Determine the child node type based on text_style
@@ -757,7 +761,7 @@ export function convertElementalToTiptap(
             {
               type: childType,
               attrs: childAttrs,
-              content: parseMDContent(node.content),
+              content: quoteContent.trim() ? parseMDContent(quoteContent) : [],
             },
           ];
         }


### PR DESCRIPTION
## Summary

Brand CSS configured in `templateOverride.head` uses `c--block-*` and `c--text-*` CSS classes to target specific elemental blocks in rendered emails. The designer preview was missing these classes on its Tiptap components, so brand CSS styles weren't applied in the editor.

- **Headings** had only `c--text-h{level}` but lacked `c--block c--block-text`, so `.c--block-text *` brand selectors didn't match
- **Text blocks** were missing `c--text-text` (the specific text-type class used in rendered output)
- **Blockquotes** were missing `c--text-quote`
- All block types now carry the same `c--block c--block-*` classes as the backend MJML output

Classes added to both React components (visible DOM) and `renderHTML` methods (clipboard serialization).

## Test plan

- [ ] Open a template with a brand that has `templateOverride.head` CSS targeting `c--block-text`, `c--text-h1`, `c--text-quote`, etc.
- [ ] Verify heading blocks now pick up `.c--block-text *` styles (e.g. font-family, color)
- [ ] Verify text blocks have `c--text-text` class in DOM
- [ ] Verify blockquote blocks have `c--text-quote` class in DOM
- [ ] Send a test email and compare rendered output styling with designer preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzJ6Nav4ChdexTxMYVHeKL