### PR TITLE
fix: serialize button textColor in TipTap→Elemental conversion

### DIFF
--- a/docs/summaries/handoff-2026-06-30-C-19051-execute.md
+++ b/docs/summaries/handoff-2026-06-30-C-19051-execute.md
@@ -1,0 +1,38 @@
+# Session Handoff: Fix outlined primary button white-on-white after publish+reload
+**Date:** 2026-06-30
+**Session Duration:** ~30 minutes
+**Session Focus:** Fix Inbox channel outlined primary button losing text color on round-trip
+**Context Usage at Handoff:** ~40%
+
+## What Was Accomplished
+1. Investigated and root-caused the bug: `convertTiptapToElemental` `case "button"` did not serialize `textColor` as Elemental `color` field, while `case "buttonRow"` did. An incorrect comment at line 557 claimed it was unsupported.
+2. Fixed the serialization gap by adding `textColor` → `color` output in the single button conversion path.
+3. Updated 2 existing tests that encoded the bug (expected no `color` in output) and added 2 new targeted tests.
+4. Corrected the misleading `@deprecated` JSDoc on `ElementalActionNode.color` in the type definitions.
+5. Full test suite passes: 2726/2726 tests green.
+
+## Decisions Made This Session
+- Serialize `textColor` as `color` unconditionally (not just for Inbox) — mirrors `buttonRow` behavior and is safe since `color` is optional in `ElementalActionNode`. STATUS: confirmed.
+- Removed `@deprecated` tag from `color` field — it IS actively used by Inbox outlined/filled style detection. STATUS: confirmed.
+
+## Conditional Logic Established
+- IF a single `button` node has `textColor` set THEN `convertTiptapToElemental` emits `color` in the Elemental output BECAUSE without it, the Inbox `onUpdate` handler (Inbox.tsx:312) drops the color on every keystroke, corrupting the saved Elemental.
+
+## Files Created or Modified
+| File Path | Action | Description |
+|-----------|--------|-------------|
+| `packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts` | Modified | Added `textColor` → `color` serialization in `case "button"` (line ~557), removed incorrect comment |
+| `packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.test.tsx` | Modified | Updated 2 existing expectations to include `color`, added 2 new tests for textColor serialization |
+| `packages/react-designer/src/types/elemental.types.ts` | Modified | Replaced misleading `@deprecated` JSDoc on `ElementalActionNode.color` with accurate description |
+
+## What the NEXT Session Should Do
+1. **First**: Commit, push to `geraldosilva/c-19051-outlined-primary-button-renders-white-outline-after-publish`, create PR.
+2. **Then**: Manual QA in Courier Design Studio: enable only primary button in Inbox, set outline style, publish, reload, verify text is black not white.
+3. **Then**: Test with both buttons enabled (ButtonRow path) to confirm no regression.
+
+## Open Questions Requiring User Input
+- None. Fix is straightforward and all tests pass.
+
+## Files to Load Next Session
+- `packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts` — the fix location
+- `packages/react-designer/src/components/extensions/Button/inboxButtonStyle.ts` — sentinel color definitions (context)

--- a/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.test.tsx
+++ b/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.test.tsx
@@ -504,6 +504,7 @@ describe("convertTiptapToElemental", () => {
         style: "button",
         align: "center",
         background_color: "#0066cc",
+        color: "#ffffff",
         padding: "12px 24px",
       },
     ]);
@@ -1370,8 +1371,8 @@ describe("convertTiptapToElemental", () => {
         href: "https://example.com/shop",
         style: "button",
         background_color: "#007bff",
-        // Note: color (textColor) is not supported by Elemental for buttons
-        align: "center", // Implementation always adds default alignment
+        color: "#ffffff",
+        align: "center",
       },
     ]);
   });
@@ -2765,6 +2766,48 @@ describe("convertTiptapToElemental", () => {
       expect(result).toHaveLength(2);
       expect((result[0] as any).if).toEqual(ifExpr);
       expect((result[1] as any).if).toEqual(ifExpr);
+    });
+  });
+
+  describe("button textColor serialization", () => {
+    it("serializes textColor as color on single button nodes", () => {
+      const tiptap = createTiptapDoc([
+        {
+          type: "button",
+          attrs: {
+            label: "Click me",
+            link: "https://example.com",
+            backgroundColor: "#ffffff",
+            textColor: "#000000",
+          },
+          content: [{ type: "text", text: "Click me" }],
+        },
+      ]);
+
+      const result = convertTiptapToElemental(tiptap);
+
+      expect(result).toHaveLength(1);
+      expect((result[0] as any).background_color).toBe("#ffffff");
+      expect((result[0] as any).color).toBe("#000000");
+    });
+
+    it("omits color when textColor is not set", () => {
+      const tiptap = createTiptapDoc([
+        {
+          type: "button",
+          attrs: {
+            label: "Click me",
+            link: "https://example.com",
+            backgroundColor: "#0085FF",
+          },
+          content: [{ type: "text", text: "Click me" }],
+        },
+      ]);
+
+      const result = convertTiptapToElemental(tiptap);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).not.toHaveProperty("color");
     });
   });
 

--- a/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts
+++ b/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts
@@ -554,7 +554,9 @@ export function convertTiptapToElemental(tiptap: TiptapDoc): ElementalNode[] {
           actionNode.background_color = node.attrs.backgroundColor as string;
         }
 
-        // Note: textColor (color) is not supported by Elemental for buttons
+        if (node.attrs?.textColor) {
+          actionNode.color = node.attrs.textColor as string;
+        }
 
         if (
           node.attrs?.paddingVertical !== undefined ||

--- a/packages/react-designer/src/types/elemental.types.ts
+++ b/packages/react-designer/src/types/elemental.types.ts
@@ -198,10 +198,7 @@ export interface ElementalActionNode extends IsElementalNode {
   border_size?: string;
   padding?: string;
   disable_tracking?: boolean;
-  /**
-   * @deprecated Legacy text color. Not supported by Elemental.
-   * Kept for backward compatibility when reading old templates.
-   */
+  /** Text color for the action button (e.g., "#000000"). Used by Inbox to distinguish filled vs outlined styles. */
   color?: string;
   /**
    * @deprecated Legacy nested border format. Use flat `border_radius` and `border_size` instead.


### PR DESCRIPTION
## Summary
- **Bug**: Inbox outlined primary button renders white-on-white (invisible) after publish + reload
- **Root cause**: `convertTiptapToElemental` `case "button"` did not serialize `textColor` as Elemental `color` field — the `onUpdate` handler in Inbox.tsx overwrites the sidebar's correct Elemental on every keystroke, dropping the color
- **Fix**: Added `textColor` → `color` serialization in the single button path, matching the existing `buttonRow` behavior

## Test plan
- [x] Added 2 new tests for single button `textColor` serialization
- [x] Updated 2 existing test expectations to include `color`
- [x] Full test suite passes (2726/2726)
- [ ] Manual QA: enable only primary button in Inbox, set outline style, publish, reload — verify text is black
- [ ] Manual QA: both buttons enabled (ButtonRow path) — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)