### PR TITLE
Pass OpenAI API key to Codex review workflow

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -33,3 +33,4 @@ jobs:
       max_inline_comments: "10"
     secrets:
       codex_auth_json: ${{ secrets.CODEX_AUTH_JSON }}
+      openai_api_key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary
- pass OPENAI_API_KEY into the shared Codex review reusable workflow
- keeps the old codex_auth_json mapping optional while v1 supports both auth paths

## Tests
- not run (workflow-only wiring change)