### PR TITLE
[C-16402] Link tracking toggle for links and action buttons

### DIFF
--- a/packages/react-designer/src/components/Providers/TemplateProvider.tsx
+++ b/packages/react-designer/src/components/Providers/TemplateProvider.tsx
@@ -13,6 +13,7 @@ import {
 import {
   availableVariablesAtom,
   disableVariablesAutocompleteAtom,
+  linkTrackingEnabledAtom,
   sampleDataAtom,
   variablesEnabledAtom,
   variableValidationAtom,
@@ -46,6 +47,12 @@ type TemplateProviderProps = BasicProviderProps & {
   // Sample data payload for validating loop data paths
   sampleData?: Record<string, unknown>;
   /**
+   * Whether click-through (link) tracking is enabled for the workspace.
+   * When false, the "Link tracking" toggle is disabled and forced off.
+   * @default true
+   */
+  linkTrackingEnabled?: boolean;
+  /**
    * Whether the designer should render its own Sonner `<Toaster />`.
    * Set to `false` when the host app already provides one to avoid duplicate toasts.
    * @default true
@@ -65,6 +72,7 @@ const TemplateProviderContext: React.FC<TemplateProviderProps> = ({
   disableVariablesAutocomplete = false,
   variableValidation,
   sampleData,
+  linkTrackingEnabled = true,
   renderToaster = true,
 }) => {
   const [, setApiUrl] = useAtom(apiUrlAtom);
@@ -75,6 +83,7 @@ const TemplateProviderContext: React.FC<TemplateProviderProps> = ({
   const [, setAvailableVariables] = useAtom(availableVariablesAtom);
   const [, setDisableAutocomplete] = useAtom(disableVariablesAutocompleteAtom);
   const [, setVariablesEnabled] = useAtom(variablesEnabledAtom);
+  const [, setLinkTrackingEnabled] = useAtom(linkTrackingEnabledAtom);
   const [, setVariableValidation] = useAtom(variableValidationAtom);
   const [, setSampleData] = useAtom(sampleDataAtom);
   const [, setRenderToaster] = useAtom(renderToasterAtom);
@@ -107,6 +116,11 @@ const TemplateProviderContext: React.FC<TemplateProviderProps> = ({
     setDisableAutocomplete,
     setVariablesEnabled,
   ]);
+
+  // Sync whether link (click-through) tracking is enabled for the workspace
+  useEffect(() => {
+    setLinkTrackingEnabled(linkTrackingEnabled ?? true);
+  }, [linkTrackingEnabled, setLinkTrackingEnabled]);
 
   // Sync variable validation config (only when explicitly provided, so that
   // TemplateEditor's own variableValidation prop isn't overwritten by a parent

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Email/EmailEditor.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Email/EmailEditor.test.tsx
@@ -253,6 +253,7 @@ vi.mock("@/components/TemplateEditor/store", () => ({
   blockPresetsAtom: "blockPresetsAtom",
   blockDefaultsAtom: "blockDefaultsAtom",
   variablesEnabledAtom: "variablesEnabledAtom",
+  linkTrackingEnabledAtom: "linkTrackingEnabledAtom",
   previewLocaleAtom: "previewLocaleAtom",
   getFormUpdating: () => false,
   setFormUpdating: () => {},

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.test.tsx
@@ -76,6 +76,7 @@ vi.mock("@/components/TemplateEditor/store", () => ({
   blockPresetsAtom: "blockPresetsAtom",
   blockDefaultsAtom: "blockDefaultsAtom",
   variablesEnabledAtom: "variablesEnabledAtom",
+  linkTrackingEnabledAtom: "linkTrackingEnabledAtom",
   previewLocaleAtom: "previewLocaleAtom",
   getFormUpdating: () => false,
   setFormUpdating: () => {},

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/SideBar/SideBar.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/SideBar/SideBar.test.tsx
@@ -87,6 +87,7 @@ vi.mock("@/components/TemplateEditor/store", () => ({
   pendingAutoSaveAtom: "pendingAutoSaveAtom",
   flushFunctionsAtom: "flushFunctionsAtom",
   variablesEnabledAtom: "variablesEnabledAtom",
+  linkTrackingEnabledAtom: "linkTrackingEnabledAtom",
   setFormUpdating: vi.fn(),
   getFormUpdating: vi.fn(() => false),
 }));

--- a/packages/react-designer/src/components/TemplateEditor/Channels/MSTeams/MSTeams.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/MSTeams/MSTeams.test.tsx
@@ -79,6 +79,7 @@ vi.mock("@/components/TemplateEditor/store", () => ({
   blockDefaultsAtom: "blockDefaultsAtom",
   visibleBlocksAtom: "visibleBlocksAtom",
   variablesEnabledAtom: "variablesEnabledAtom",
+  linkTrackingEnabledAtom: "linkTrackingEnabledAtom",
   previewLocaleAtom: "previewLocaleAtom",
   isPresetReference: () => false,
   getFormUpdating: () => false,

--- a/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.test.tsx
@@ -77,6 +77,7 @@ vi.mock("@/components/TemplateEditor/store", () => ({
   blockPresetsAtom: "blockPresetsAtom",
   blockDefaultsAtom: "blockDefaultsAtom",
   variablesEnabledAtom: "variablesEnabledAtom",
+  linkTrackingEnabledAtom: "linkTrackingEnabledAtom",
   previewLocaleAtom: "previewLocaleAtom",
   getFormUpdating: () => false,
   setFormUpdating: () => {},

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Slack/Slack.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Slack/Slack.test.tsx
@@ -80,6 +80,7 @@ vi.mock("@/components/TemplateEditor/store", () => ({
   blockDefaultsAtom: "blockDefaultsAtom",
   visibleBlocksAtom: "visibleBlocksAtom",
   variablesEnabledAtom: "variablesEnabledAtom",
+  linkTrackingEnabledAtom: "linkTrackingEnabledAtom",
   previewLocaleAtom: "previewLocaleAtom",
   isPresetReference: () => false,
   getFormUpdating: () => false,

--- a/packages/react-designer/src/components/TemplateEditor/TemplateEditor.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/TemplateEditor.tsx
@@ -44,6 +44,7 @@ import {
   availableVariablesAtom,
   disableVariablesAutocompleteAtom,
   variablesEnabledAtom,
+  linkTrackingEnabledAtom,
   readOnlyAtom,
   sampleDataAtom,
   previewLocaleAtom,
@@ -72,6 +73,12 @@ export interface TemplateEditorProps
    * Allows restricting which variable names are allowed and defining behavior on validation failure.
    */
   variableValidation?: VariableValidationConfig;
+  /**
+   * Whether click-through (link) tracking is enabled for the workspace.
+   * When false, the "Link tracking" toggle is disabled and forced off.
+   * @default true
+   */
+  linkTrackingEnabled?: boolean;
   hidePublish?: boolean;
   autoSave?: boolean;
   autoSaveDebounce?: number;
@@ -132,6 +139,7 @@ const TemplateEditorComponent: React.FC<TemplateEditorProps> = ({
   variables,
   disableVariablesAutocomplete = false,
   variableValidation,
+  linkTrackingEnabled = true,
   hidePublish = false,
   autoSave = true,
   autoSaveDebounce = 500,
@@ -152,6 +160,7 @@ const TemplateEditorComponent: React.FC<TemplateEditorProps> = ({
   const setAvailableVariables = useSetAtom(availableVariablesAtom);
   const setDisableVariablesAutocomplete = useSetAtom(disableVariablesAutocompleteAtom);
   const setVariablesEnabled = useSetAtom(variablesEnabledAtom);
+  const setLinkTrackingEnabled = useSetAtom(linkTrackingEnabledAtom);
   const setReadOnly = useSetAtom(readOnlyAtom);
   const setSampleData = useSetAtom(sampleDataAtom);
   const setPreviewLocale = useSetAtom(previewLocaleAtom);
@@ -330,6 +339,11 @@ const TemplateEditorComponent: React.FC<TemplateEditorProps> = ({
   useEffect(() => {
     setVariablesEnabled(variables !== undefined);
   }, [variables, setVariablesEnabled]);
+
+  // Sync whether link (click-through) tracking is enabled for the workspace
+  useEffect(() => {
+    setLinkTrackingEnabled(linkTrackingEnabled ?? true);
+  }, [linkTrackingEnabled, setLinkTrackingEnabled]);
 
   // Sync available variables for autocomplete
   useEffect(() => {

--- a/packages/react-designer/src/components/TemplateEditor/store.ts
+++ b/packages/react-designer/src/components/TemplateEditor/store.ts
@@ -75,6 +75,11 @@ export const variableValuesAtom = atom<Record<string, string>>({});
 // - Variable autocomplete is not shown
 export const variablesEnabledAtom = atom<boolean>(true);
 
+// Atom to track whether link (click-through) tracking is enabled for the workspace.
+// When false, the "Link tracking" toggle in LinkBubble/LinkForm/ButtonForm is forced
+// off and disabled (visual only — the stored `disableTracking` attr is not mutated).
+export const linkTrackingEnabledAtom = atom<boolean>(true);
+
 // Atom to store available variables for autocomplete suggestions
 // This is populated from the `variables` prop passed to TemplateEditor/BrandEditor
 export const availableVariablesAtom = atom<Record<string, unknown>>({});

--- a/packages/react-designer/src/components/extensions/Button/Button.test.tsx
+++ b/packages/react-designer/src/components/extensions/Button/Button.test.tsx
@@ -135,6 +135,11 @@ describe("Button Extension", () => {
       expect(defaultButtonProps.borderRadius).toBe(0);
     });
 
+    it("should default disableTracking to false (link tracking enabled)", () => {
+      // Per-button link-tracking suppression; serialized as disable_tracking only when true.
+      expect(defaultButtonProps.disableTracking).toBe(false);
+    });
+
     it("should have legacy typography attributes with default values", () => {
       // These attrs are kept for backward compat but formatting is no longer applied
       expect(defaultButtonProps.fontWeight).toBe("normal");

--- a/packages/react-designer/src/components/extensions/Button/Button.ts
+++ b/packages/react-designer/src/components/extensions/Button/Button.ts
@@ -41,6 +41,7 @@ export const defaultButtonProps: ButtonProps = {
   fontStyle: "normal",
   isUnderline: false,
   isStrike: false,
+  disableTracking: false,
   // Legacy properties - kept for backward compat but not used in new templates
   textColor: "#ffffff",
   borderColor: "transparent",
@@ -164,6 +165,12 @@ export const Button = Node.create({
         renderHTML: (attributes) => ({
           "data-is-strike": attributes.isStrike,
         }),
+      },
+      disableTracking: {
+        default: defaultButtonProps.disableTracking,
+        parseHTML: (element) => element.getAttribute("data-disable-tracking") === "true",
+        renderHTML: (attributes) =>
+          attributes.disableTracking ? { "data-disable-tracking": "true" } : {},
       },
       id: {
         default: () => `node-${uuidv4()}`,

--- a/packages/react-designer/src/components/extensions/Button/Button.types.ts
+++ b/packages/react-designer/src/components/extensions/Button/Button.types.ts
@@ -12,6 +12,7 @@ export const buttonSchema = z.object({
   fontStyle: z.enum(["normal", "italic"]),
   isUnderline: z.boolean(),
   isStrike: z.boolean(),
+  disableTracking: z.boolean().optional(),
   // Legacy properties - kept for backward compatibility but not editable in UI
   textColor: z.string().optional(),
   borderColor: z.string().optional(),
@@ -29,6 +30,8 @@ export interface ButtonProps {
   fontStyle: "normal" | "italic";
   isUnderline: boolean;
   isStrike: boolean;
+  /** When true, click-through tracking is disabled for this action button. */
+  disableTracking?: boolean;
   /** @deprecated Legacy property - not supported by Elemental */
   textColor?: string;
   /** @deprecated Legacy property - not supported by Elemental */

--- a/packages/react-designer/src/components/extensions/Button/ButtonForm.tsx
+++ b/packages/react-designer/src/components/extensions/Button/ButtonForm.tsx
@@ -4,10 +4,12 @@ import {
   FormControl,
   FormField,
   FormItem,
+  FormLabel,
   FormMessage,
   Input,
   InputColor,
   PrefixInput,
+  Switch,
   ToggleGroup,
   ToggleGroupItem,
 } from "@/components/ui-kit";
@@ -19,9 +21,11 @@ import {
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import type { Editor } from "@tiptap/react";
+import { useAtomValue } from "jotai";
 import { useCallback, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import type { z } from "zod";
+import { Tooltip } from "@/components/ui/Tooltip";
 import { useNodeAttributes } from "../../hooks";
 import { FormHeader } from "../../ui/FormHeader";
 import { VariableTextarea } from "../../ui/VariableEditor";
@@ -33,7 +37,7 @@ import {
   findButtonNodeAtPosition,
   updateButtonLabelAndContent,
 } from "./buttonUtils";
-import { setFormUpdating } from "@/components/TemplateEditor/store";
+import { linkTrackingEnabledAtom, setFormUpdating } from "@/components/TemplateEditor/store";
 import { ConditionsSection } from "../../ui/Conditions";
 import type { ElementalIfCondition } from "@/types/conditions.types";
 
@@ -49,6 +53,7 @@ interface ButtonFormProps {
 }
 
 export const ButtonForm = ({ element, editor, hideCloseButton = false }: ButtonFormProps) => {
+  const linkTrackingEnabled = useAtomValue(linkTrackingEnabledAtom);
   const form = useForm<z.infer<typeof buttonSchema>>({
     resolver: zodResolver(buttonSchema),
     defaultValues: {
@@ -200,6 +205,37 @@ export const ButtonForm = ({ element, editor, hideCloseButton = false }: ButtonF
             </FormItem>
           )}
         />
+        <div className="courier-mt-4">
+          <FormField
+            control={form.control}
+            name="disableTracking"
+            render={({ field }) => (
+              <Tooltip
+                enabled={!linkTrackingEnabled}
+                title="Click-through tracking is turned off for this workspace"
+              >
+                <FormItem className="courier-flex courier-flex-row courier-items-center courier-justify-between">
+                  <FormLabel className="!courier-m-0">Link tracking</FormLabel>
+                  <FormControl>
+                    <Switch
+                      checked={linkTrackingEnabled ? !field.value : false}
+                      disabled={!linkTrackingEnabled}
+                      onCheckedChange={(checked) => {
+                        // Switch reflects "tracking enabled"; the stored attr is its inverse.
+                        field.onChange(!checked);
+                        updateNodeAttributes({
+                          ...form.getValues(),
+                          disableTracking: !checked,
+                        });
+                      }}
+                      className="!courier-m-0"
+                    />
+                  </FormControl>
+                </FormItem>
+              </Tooltip>
+            )}
+          />
+        </div>
         <Divider className="courier-mt-6 courier-mb-4" />
         <h4 className="courier-text-sm courier-font-medium courier-mb-3">Background</h4>
         <FormField

--- a/packages/react-designer/src/components/extensions/Link/Link.ts
+++ b/packages/react-designer/src/components/extensions/Link/Link.ts
@@ -15,6 +15,12 @@ export const Link = TiptapLink.extend({
       originalHref: {
         default: null,
       },
+      disableTracking: {
+        default: false,
+        parseHTML: (element) => element.getAttribute("data-disable-tracking") === "true",
+        renderHTML: (attributes) =>
+          attributes.disableTracking ? { "data-disable-tracking": "true" } : {},
+      },
     };
   },
 

--- a/packages/react-designer/src/components/extensions/Link/LinkBubble.test.tsx
+++ b/packages/react-designer/src/components/extensions/Link/LinkBubble.test.tsx
@@ -3,7 +3,13 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Provider, createStore } from "jotai";
 import { createElement } from "react";
 import { pendingLinkAtom, setPendingLinkAtom } from "@/components/ui/TextMenu/store";
+import { linkTrackingEnabledAtom, setFormUpdating } from "@/components/TemplateEditor/store";
 import { LinkBubble } from "./LinkBubble";
+
+vi.mock("@/components/TemplateEditor/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/TemplateEditor/store")>();
+  return { ...actual, setFormUpdating: vi.fn() };
+});
 
 const mockEditor = {
   commands: {
@@ -32,9 +38,15 @@ vi.mock("@tiptap/react", () => ({
   useCurrentEditor: () => ({ editor: mockEditor }),
 }));
 
-function renderWithStore(pendingLink: { mark?: any; link?: { from: number; to: number } } | null) {
+function renderWithStore(
+  pendingLink: { mark?: any; link?: { from: number; to: number } } | null,
+  opts?: { linkTrackingEnabled?: boolean }
+) {
   const store = createStore();
   store.set(pendingLinkAtom, pendingLink);
+  if (opts?.linkTrackingEnabled !== undefined) {
+    store.set(linkTrackingEnabledAtom, opts.linkTrackingEnabled);
+  }
 
   const wrapper = ({ children }: { children: React.ReactNode }) =>
     createElement(Provider, { store }, children);
@@ -175,5 +187,98 @@ describe("LinkBubble", () => {
     );
 
     windowOpen.mockRestore();
+  });
+
+  describe("Link tracking toggle", () => {
+    it("renders the Link tracking toggle when a link is present", () => {
+      renderWithStore({ link: { from: 1, to: 5 } });
+      expect(screen.getByText("Link tracking")).toBeInTheDocument();
+      expect(screen.getByRole("switch")).toBeInTheDocument();
+    });
+
+    it("shows tracking enabled (switch on) when disableTracking is absent", () => {
+      renderWithStore({
+        link: { from: 1, to: 5 },
+        mark: { attrs: { href: "https://example.com", target: null } },
+      });
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("shows tracking disabled (switch off) when disableTracking is true", () => {
+      renderWithStore({
+        link: { from: 1, to: 5 },
+        mark: { attrs: { href: "https://example.com", target: null, disableTracking: true } },
+      });
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("writes disable_tracking=true (inverted) onto the link when tracking is toggled off", () => {
+      renderWithStore({
+        link: { from: 1, to: 5 },
+        mark: { attrs: { href: "https://example.com", target: null } },
+      });
+
+      fireEvent.click(screen.getByRole("switch")); // enabled -> disabled
+
+      const chainResult = mockEditor.chain.mock.results.at(-1)?.value;
+      expect(chainResult.setLink).toHaveBeenCalledWith(
+        expect.objectContaining({ href: "https://example.com", disableTracking: true })
+      );
+    });
+
+    it("regression: toggling does not close the bubble and uses the form-updating guard", () => {
+      const { store } = renderWithStore({
+        link: { from: 1, to: 5 },
+        mark: { attrs: { href: "https://example.com", target: null } },
+      });
+
+      fireEvent.click(screen.getByRole("switch"));
+
+      // pendingLink still holds the link range, so the bubble stays open.
+      expect(store.get(pendingLinkAtom)?.link).toEqual({ from: 1, to: 5 });
+      // onSelectionUpdate is suppressed for this form-initiated edit.
+      expect(setFormUpdating).toHaveBeenCalledWith(true);
+    });
+
+    describe("when workspace click-through tracking is disabled", () => {
+      it("renders the switch disabled and forced off even without disableTracking", () => {
+        renderWithStore(
+          {
+            link: { from: 1, to: 5 },
+            mark: { attrs: { href: "https://example.com", target: null } },
+          },
+          { linkTrackingEnabled: false }
+        );
+        const toggle = screen.getByRole("switch");
+        expect(toggle).toBeDisabled();
+        expect(toggle).toHaveAttribute("aria-checked", "false");
+      });
+
+      it("does not mutate the stored disableTracking attr when clicking the disabled switch", () => {
+        renderWithStore(
+          {
+            link: { from: 1, to: 5 },
+            mark: { attrs: { href: "https://example.com", target: null } },
+          },
+          { linkTrackingEnabled: false }
+        );
+        fireEvent.click(screen.getByRole("switch"));
+        // Disabled switch never invokes the change handler / editor chain.
+        expect(setFormUpdating).not.toHaveBeenCalled();
+      });
+    });
+
+    it("behaves as before when workspace tracking is enabled", () => {
+      renderWithStore(
+        {
+          link: { from: 1, to: 5 },
+          mark: { attrs: { href: "https://example.com", target: null } },
+        },
+        { linkTrackingEnabled: true }
+      );
+      const toggle = screen.getByRole("switch");
+      expect(toggle).not.toBeDisabled();
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+    });
   });
 });

--- a/packages/react-designer/src/components/extensions/Link/LinkBubble.tsx
+++ b/packages/react-designer/src/components/extensions/Link/LinkBubble.tsx
@@ -1,3 +1,6 @@
+import { Switch } from "@/components/ui-kit";
+import { Tooltip } from "@/components/ui/Tooltip";
+import { linkTrackingEnabledAtom, setFormUpdating } from "@/components/TemplateEditor/store";
 import { pendingLinkAtom, setPendingLinkAtom } from "@/components/ui/TextMenu/store";
 import { cn } from "@/lib/utils";
 import { useCurrentEditor } from "@tiptap/react";
@@ -8,8 +11,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 export const LinkBubble = () => {
   const { editor } = useCurrentEditor();
   const pendingLink = useAtomValue(pendingLinkAtom);
+  const linkTrackingEnabled = useAtomValue(linkTrackingEnabledAtom);
   const setPendingLink = useSetAtom(setPendingLinkAtom);
   const [url, setUrl] = useState("");
+  const [disableTracking, setDisableTracking] = useState(false);
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -24,6 +29,7 @@ export const LinkBubble = () => {
     }
 
     setUrl(mark?.attrs.href || "");
+    setDisableTracking(!!mark?.attrs.disableTracking);
 
     const { from, to } = pendingLink.link;
     const start = editor.view.coordsAtPos(from);
@@ -66,18 +72,48 @@ export const LinkBubble = () => {
       editor.commands.setTextSelection({ from, to });
       editor.commands.unsetLink();
     } else {
-      editor
-        .chain()
-        .focus()
-        .unsetLink()
-        .setTextSelection({ from, to })
-        .setLink({ href: trimmed, target: mark?.attrs.target || null })
-        .run();
+      // Assigned to a variable so the extra `disableTracking` attribute is not
+      // rejected by @tiptap/extension-link's setLink type (excess-property check).
+      const linkAttrs = {
+        href: trimmed,
+        target: mark?.attrs.target || null,
+        disableTracking,
+      };
+      editor.chain().focus().unsetLink().setTextSelection({ from, to }).setLink(linkAttrs).run();
       editor.commands.setTextSelection(to);
     }
 
     setPendingLink(null);
-  }, [editor, pendingLink, url, mark, setPendingLink]);
+  }, [editor, pendingLink, url, mark, disableTracking, setPendingLink]);
+
+  const handleToggleTracking = useCallback(
+    (trackingEnabled: boolean) => {
+      // Switch reflects "tracking enabled"; the stored attr is its inverse.
+      const nextDisableTracking = !trackingEnabled;
+      setDisableTracking(nextDisableTracking);
+
+      // Persist immediately onto the existing link so the change isn't lost if
+      // the bubble is dismissed by an outside click. If there is no link yet
+      // (empty url), the value is applied on save.
+      if (!editor || !pendingLink?.link) return;
+      const trimmed = url.trim();
+      if (!trimmed) return;
+
+      const { from, to } = pendingLink.link;
+      const linkAttrs = {
+        href: trimmed,
+        target: mark?.attrs.target || null,
+        disableTracking: nextDisableTracking,
+      };
+      // Suppress onSelectionUpdate for this form-initiated edit so it doesn't
+      // clear pendingLink (which would close this popover). Keep the selection
+      // on the link range — do NOT collapse it — so the bubble stays anchored.
+      setFormUpdating(true);
+      editor.chain().focus().setTextSelection({ from, to }).unsetLink().setLink(linkAttrs).run();
+      requestAnimationFrame(() => setFormUpdating(false));
+    },
+    [editor, pendingLink, url, mark]
+  );
 
   const handleRemove = useCallback(() => {
     if (!editor || !pendingLink?.link) return;
@@ -120,74 +156,96 @@ export const LinkBubble = () => {
     >
       <div
         className={cn(
-          "courier-flex courier-items-center courier-gap-1 courier-rounded-lg",
+          "courier-flex courier-flex-col courier-gap-1 courier-rounded-lg",
           "courier-border courier-border-neutral-200 courier-bg-white courier-p-1 courier-shadow-lg",
           "dark:courier-border-neutral-700 dark:courier-bg-neutral-800"
         )}
       >
-        <input
-          ref={inputRef}
-          type="text"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder="Paste a link..."
-          className={cn(
-            "courier-h-7 courier-w-56 courier-rounded courier-border-none courier-bg-transparent",
-            "courier-px-2 courier-text-sm courier-outline-none",
-            "courier-text-neutral-900 placeholder:courier-text-neutral-400",
-            "dark:courier-text-neutral-100 dark:placeholder:courier-text-neutral-500"
-          )}
-        />
-        <button
-          type="button"
-          title="Save link"
-          onMouseDown={(e) => {
-            e.preventDefault();
-            handleSave();
-          }}
-          className={cn(
-            "courier-flex courier-h-7 courier-w-7 courier-items-center courier-justify-center",
-            "courier-rounded courier-border-none courier-bg-transparent courier-text-neutral-600",
-            "hover:courier-bg-neutral-100 dark:courier-text-neutral-300 dark:hover:courier-bg-neutral-700"
-          )}
+        <div className="courier-flex courier-items-center courier-gap-1">
+          <input
+            ref={inputRef}
+            type="text"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Paste a link..."
+            className={cn(
+              "courier-h-7 courier-w-56 courier-rounded courier-border-none courier-bg-transparent",
+              "courier-px-2 courier-text-sm courier-outline-none",
+              "courier-text-neutral-900 placeholder:courier-text-neutral-400",
+              "dark:courier-text-neutral-100 dark:placeholder:courier-text-neutral-500"
+            )}
+          />
+          <button
+            type="button"
+            title="Save link"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              handleSave();
+            }}
+            className={cn(
+              "courier-flex courier-h-7 courier-w-7 courier-items-center courier-justify-center",
+              "courier-rounded courier-border-none courier-bg-transparent courier-text-neutral-600",
+              "hover:courier-bg-neutral-100 dark:courier-text-neutral-300 dark:hover:courier-bg-neutral-700"
+            )}
+          >
+            <Check className="courier-h-4 courier-w-4" strokeWidth={1.5} />
+          </button>
+          <button
+            type="button"
+            title="Open link"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              handleOpenLink();
+            }}
+            disabled={!url.trim()}
+            className={cn(
+              "courier-flex courier-h-7 courier-w-7 courier-items-center courier-justify-center",
+              "courier-rounded courier-border-none courier-bg-transparent courier-text-neutral-600",
+              "hover:courier-bg-neutral-100 disabled:courier-opacity-40 disabled:courier-pointer-events-none",
+              "dark:courier-text-neutral-300 dark:hover:courier-bg-neutral-700"
+            )}
+          >
+            <ExternalLink className="courier-h-4 courier-w-4" strokeWidth={1.5} />
+          </button>
+          <button
+            type="button"
+            title="Remove link"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              handleRemove();
+            }}
+            disabled={!mark}
+            className={cn(
+              "courier-flex courier-h-7 courier-w-7 courier-items-center courier-justify-center",
+              "courier-rounded courier-border-none courier-bg-transparent courier-text-neutral-600",
+              "hover:courier-bg-neutral-100 disabled:courier-opacity-40 disabled:courier-pointer-events-none",
+              "dark:courier-text-neutral-300 dark:hover:courier-bg-neutral-700"
+            )}
+          >
+            <Trash2 className="courier-h-4 courier-w-4" strokeWidth={1.5} />
+          </button>
+        </div>
+        <Tooltip
+          enabled={!linkTrackingEnabled}
+          title="Click-through tracking is turned off for this workspace"
         >
-          <Check className="courier-h-4 courier-w-4" strokeWidth={1.5} />
-        </button>
-        <button
-          type="button"
-          title="Open link"
-          onMouseDown={(e) => {
-            e.preventDefault();
-            handleOpenLink();
-          }}
-          disabled={!url.trim()}
-          className={cn(
-            "courier-flex courier-h-7 courier-w-7 courier-items-center courier-justify-center",
-            "courier-rounded courier-border-none courier-bg-transparent courier-text-neutral-600",
-            "hover:courier-bg-neutral-100 disabled:courier-opacity-40 disabled:courier-pointer-events-none",
-            "dark:courier-text-neutral-300 dark:hover:courier-bg-neutral-700"
-          )}
-        >
-          <ExternalLink className="courier-h-4 courier-w-4" strokeWidth={1.5} />
-        </button>
-        <button
-          type="button"
-          title="Remove link"
-          onMouseDown={(e) => {
-            e.preventDefault();
-            handleRemove();
-          }}
-          disabled={!mark}
-          className={cn(
-            "courier-flex courier-h-7 courier-w-7 courier-items-center courier-justify-center",
-            "courier-rounded courier-border-none courier-bg-transparent courier-text-neutral-600",
-            "hover:courier-bg-neutral-100 disabled:courier-opacity-40 disabled:courier-pointer-events-none",
-            "dark:courier-text-neutral-300 dark:hover:courier-bg-neutral-700"
-          )}
-        >
-          <Trash2 className="courier-h-4 courier-w-4" strokeWidth={1.5} />
-        </button>
+          <div className="courier-flex courier-items-center courier-justify-between courier-px-2 courier-py-1">
+            <span
+              className={cn(
+                "courier-text-sm courier-text-neutral-700",
+                "dark:courier-text-neutral-300"
+              )}
+            >
+              Link tracking
+            </span>
+            <Switch
+              checked={linkTrackingEnabled && !disableTracking}
+              disabled={!linkTrackingEnabled}
+              onCheckedChange={handleToggleTracking}
+            />
+          </div>
+        </Tooltip>
       </div>
     </div>
   );

--- a/packages/react-designer/src/components/extensions/Link/LinkForm.test.tsx
+++ b/packages/react-designer/src/components/extensions/Link/LinkForm.test.tsx
@@ -9,6 +9,7 @@ import { Paragraph } from "@tiptap/extension-paragraph";
 import { Text } from "@tiptap/extension-text";
 import { Link } from "./Link";
 import type { Mark } from "@tiptap/pm/model";
+import { linkTrackingEnabledAtom } from "@/components/TemplateEditor/store";
 
 // Mock dependencies
 vi.mock("@/lib", () => ({
@@ -288,6 +289,53 @@ describe("LinkForm", () => {
       expect(openLinkButton.className).toContain("!courier-border-border");
       // Primary variant has bg-[#3B82F6] class
       expect(saveButton.className).toContain("courier-bg-[#3B82F6]");
+    });
+  });
+
+  describe("Link tracking toggle", () => {
+    it("renders a Link tracking toggle", () => {
+      renderLinkForm();
+      expect(screen.getByText("Link tracking")).toBeInTheDocument();
+      expect(screen.getByRole("switch")).toBeInTheDocument();
+    });
+
+    it("shows tracking enabled (switch on) when the mark has no disableTracking", () => {
+      renderLinkForm({
+        mark: { attrs: { href: "https://example.com" } } as unknown as Mark,
+      });
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+    });
+
+    it("shows tracking disabled (switch off) when the mark has disableTracking true", () => {
+      renderLinkForm({
+        mark: { attrs: { href: "https://example.com", disableTracking: true } } as unknown as Mark,
+      });
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    });
+
+    describe("when workspace click-through tracking is disabled", () => {
+      beforeEach(() => {
+        store.set(linkTrackingEnabledAtom, false);
+      });
+
+      it("renders the switch disabled and forced off even when the mark enables tracking", () => {
+        renderLinkForm({
+          mark: { attrs: { href: "https://example.com" } } as unknown as Mark,
+        });
+        const toggle = screen.getByRole("switch");
+        expect(toggle).toBeDisabled();
+        expect(toggle).toHaveAttribute("aria-checked", "false");
+      });
+    });
+
+    it("behaves as before when workspace tracking is enabled (default)", () => {
+      store.set(linkTrackingEnabledAtom, true);
+      renderLinkForm({
+        mark: { attrs: { href: "https://example.com" } } as unknown as Mark,
+      });
+      const toggle = screen.getByRole("switch");
+      expect(toggle).not.toBeDisabled();
+      expect(toggle).toHaveAttribute("aria-checked", "true");
     });
   });
 });

--- a/packages/react-designer/src/components/extensions/Link/LinkForm.tsx
+++ b/packages/react-designer/src/components/extensions/Link/LinkForm.tsx
@@ -6,21 +6,25 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
+  Switch,
 } from "@/components/ui-kit";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Mark } from "@tiptap/pm/model";
 import type { Editor } from "@tiptap/react";
-import { useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { ExternalLink } from "lucide-react";
 import { useRef, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+import { Tooltip } from "@/components/ui/Tooltip";
+import { linkTrackingEnabledAtom } from "@/components/TemplateEditor/store";
 import { TextInput } from "../../ui/TextInput";
 import { setPendingLinkAtom } from "../../ui/TextMenu/store";
 
 const linkSchema = z.object({
   href: z.string(), // Remove the min(1) validation to allow empty strings
   openInNewTab: z.boolean().default(false),
+  disableTracking: z.boolean().default(false),
 });
 
 interface LinkFormProps {
@@ -34,6 +38,7 @@ interface LinkFormProps {
 
 export const LinkForm = ({ editor, mark, pendingLink }: LinkFormProps) => {
   const setPendingLink = useSetAtom(setPendingLinkAtom);
+  const linkTrackingEnabled = useAtomValue(linkTrackingEnabledAtom);
   const textareaRef = useRef<HTMLTextAreaElement | HTMLInputElement | null>(null);
 
   const form = useForm<z.infer<typeof linkSchema>>({
@@ -41,6 +46,7 @@ export const LinkForm = ({ editor, mark, pendingLink }: LinkFormProps) => {
     defaultValues: {
       href: mark?.attrs.href || "",
       openInNewTab: mark?.attrs.target === "_blank" || false,
+      disableTracking: mark?.attrs.disableTracking || false,
     },
     mode: "onChange",
   });
@@ -50,6 +56,7 @@ export const LinkForm = ({ editor, mark, pendingLink }: LinkFormProps) => {
     form.reset({
       href: mark?.attrs.href || "",
       openInNewTab: mark?.attrs.target === "_blank" || false,
+      disableTracking: mark?.attrs.disableTracking || false,
     });
   }, [mark, form]);
 
@@ -76,12 +83,21 @@ export const LinkForm = ({ editor, mark, pendingLink }: LinkFormProps) => {
       });
     }
 
+    // Build attributes in a variable so the extra `disableTracking` attribute
+    // (not part of @tiptap/extension-link's setLink type) is not rejected by
+    // TypeScript's excess-property check while still being applied to the mark.
+    const linkAttrs = {
+      href: url,
+      target: values.openInNewTab ? "_blank" : null,
+      disableTracking: values.disableTracking,
+    };
+
     await editor
       ?.chain()
       .focus()
       .unsetLink()
       .setTextSelection({ from: pendingLink?.from || 0, to: pendingLink?.to || 0 })
-      .setLink({ href: url, target: values.openInNewTab ? "_blank" : null })
+      .setLink(linkAttrs)
       .run();
 
     // Remove text selection but keep focus by moving cursor to end of link
@@ -139,6 +155,32 @@ export const LinkForm = ({ editor, mark, pendingLink }: LinkFormProps) => {
               </FormControl>
               <FormMessage />
             </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="disableTracking"
+          render={({ field }) => (
+            <Tooltip
+              enabled={!linkTrackingEnabled}
+              title="Click-through tracking is turned off for this workspace"
+            >
+              <FormItem className="courier-flex courier-flex-row courier-items-center courier-justify-between">
+                <FormLabel className="!courier-m-0">Link tracking</FormLabel>
+                <FormControl>
+                  <Switch
+                    checked={linkTrackingEnabled ? !field.value : false}
+                    disabled={!linkTrackingEnabled}
+                    onCheckedChange={(checked) => {
+                      // Switch reflects "tracking enabled"; the stored attr is its inverse.
+                      field.onChange(!checked);
+                      form.handleSubmit(updateLink)();
+                    }}
+                    className="!courier-m-0"
+                  />
+                </FormControl>
+              </FormItem>
+            </Tooltip>
           )}
         />
         <div className="courier-flex courier-gap-2">

--- a/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.test.tsx
+++ b/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.test.tsx
@@ -909,6 +909,36 @@ describe("convertElementalToTiptap", () => {
     expect(buttonNode.content).toEqual([{ type: "text", text: "Click me" }]);
   });
 
+  it("should read disable_tracking back onto the action/button node", () => {
+    const elemental = createElementalContent([
+      {
+        type: "action",
+        content: "Click me",
+        href: "https://example.com",
+        disable_tracking: true,
+      },
+    ]);
+
+    const result = convertElementalToTiptap(elemental);
+    const buttonNode = result.content[0];
+
+    expect(buttonNode.type).toBe("button");
+    expect(buttonNode.attrs?.disableTracking).toBe(true);
+  });
+
+  it("should not set disableTracking on the button when disable_tracking is absent", () => {
+    const elemental = createElementalContent([
+      {
+        type: "action",
+        content: "Click me",
+        href: "https://example.com",
+      },
+    ]);
+
+    const result = convertElementalToTiptap(elemental);
+    expect(result.content[0].attrs).not.toHaveProperty("disableTracking");
+  });
+
   it("should default button content to fallback text when elemental content is empty", () => {
     const elemental = createElementalContent([
       {
@@ -2548,6 +2578,45 @@ describe("convertElementalToTiptap", () => {
           { type: "link", attrs: { href: "https://google.com" } },
         ]),
       });
+    });
+
+    it("should read disable_tracking back onto the link mark", () => {
+      const elemental = createElementalContent([
+        {
+          type: "text",
+          elements: [
+            {
+              type: "link",
+              content: "Google",
+              href: "https://google.com",
+              disable_tracking: true,
+            },
+          ],
+        } as any,
+      ]);
+
+      const result = convertElementalToTiptap(elemental);
+
+      expect(result.content[0].content![0]).toMatchObject({
+        type: "text",
+        text: "Google",
+        marks: expect.arrayContaining([
+          { type: "link", attrs: { href: "https://google.com", disableTracking: true } },
+        ]),
+      });
+    });
+
+    it("should not set disableTracking when disable_tracking is absent on a link", () => {
+      const elemental = createElementalContent([
+        {
+          type: "text",
+          elements: [{ type: "link", content: "Google", href: "https://google.com" }],
+        } as any,
+      ]);
+
+      const result = convertElementalToTiptap(elemental);
+      const linkMark = result.content[0].content![0].marks!.find((m) => m.type === "link");
+      expect(linkMark?.attrs).not.toHaveProperty("disableTracking");
     });
 
     it("should convert bold link elements", () => {

--- a/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
+++ b/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
@@ -85,7 +85,11 @@ function convertLinkElementToTiptapNodes(el: ElementalTextContentNode, nodes: Ti
   if (!content) return;
 
   const marks = buildMarksFromFlags(el);
-  marks.push({ type: "link", attrs: { href: el.href } });
+  const linkAttrs: Record<string, unknown> = { href: el.href };
+  if (el.disable_tracking) {
+    linkAttrs.disableTracking = true;
+  }
+  marks.push({ type: "link", attrs: linkAttrs });
 
   // Parse variables within link text
   parseTextSegmentWithVariables(content, marks, nodes);
@@ -643,6 +647,7 @@ export function convertElementalToTiptap(
               alignment: node.align === "full" ? "center" : node.align || "center",
               style: node.style,
               id: `node-${uuidv4()}`,
+              ...(node.disable_tracking && { disableTracking: true }),
               ...defaultInboxStyling,
               ...(node.background_color && { backgroundColor: node.background_color }),
               ...(node.color && { textColor: node.color }), // Legacy backward compat

--- a/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.test.tsx
+++ b/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.test.tsx
@@ -510,6 +510,47 @@ describe("convertTiptapToElemental", () => {
     ]);
   });
 
+  it("should serialize disable_tracking on an action when disableTracking is set", () => {
+    const tiptap = createTiptapDoc([
+      {
+        type: "button",
+        attrs: {
+          label: "Click me",
+          link: "https://example.com",
+          disableTracking: true,
+        },
+      },
+    ]);
+
+    const result = convertTiptapToElemental(tiptap);
+
+    expect(result).toEqual([
+      {
+        type: "action",
+        content: "Click me",
+        href: "https://example.com",
+        disable_tracking: true,
+        align: "center",
+      },
+    ]);
+  });
+
+  it("should NOT emit disable_tracking on an action when disableTracking is false/unset", () => {
+    const tiptap = createTiptapDoc([
+      {
+        type: "button",
+        attrs: {
+          label: "Click me",
+          link: "https://example.com",
+          disableTracking: false,
+        },
+      },
+    ]);
+
+    const result = convertTiptapToElemental(tiptap);
+    expect(result[0]).not.toHaveProperty("disable_tracking");
+  });
+
   it("should serialize button content from nested text nodes when present", () => {
     const tiptap = createTiptapDoc([
       {
@@ -917,6 +958,61 @@ describe("convertTiptapToElemental", () => {
         ],
       },
     ]);
+  });
+
+  it("should serialize disable_tracking on a link mark when disableTracking is set", () => {
+    const tiptap = createTiptapDoc([
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "Google",
+            marks: [
+              { type: "link", attrs: { href: "https://google.com", disableTracking: true } },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const result = convertTiptapToElemental(tiptap);
+
+    expect(result).toEqual([
+      {
+        type: "text",
+        align: "left",
+        elements: [
+          {
+            type: "link",
+            content: "Google",
+            href: "https://google.com",
+            disable_tracking: true,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("should NOT emit disable_tracking on a link when disableTracking is false/unset", () => {
+    const tiptap = createTiptapDoc([
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "Google",
+            marks: [
+              { type: "link", attrs: { href: "https://google.com", disableTracking: false } },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const result = convertTiptapToElemental(tiptap);
+    const linkEl = (result[0] as { elements: Array<Record<string, unknown>> }).elements[0];
+    expect(linkEl).not.toHaveProperty("disable_tracking");
   });
 
   it("should convert text with multiple marks", () => {

--- a/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts
+++ b/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts
@@ -179,6 +179,9 @@ const convertTiptapNodesToElements = (nodes: TiptapNode[]): ElementalTextContent
         content: node.text || "",
         href: (linkMark.attrs?.href as string) || "",
       };
+      if (linkMark.attrs?.disableTracking) {
+        el.disable_tracking = true;
+      }
       applyFormattingFlags(el, node.marks);
       elements.push(el);
       continue;
@@ -546,6 +549,10 @@ export function convertTiptapToElemental(tiptap: TiptapDoc): ElementalNode[] {
 
         if (node.attrs?.style) {
           actionNode.style = node.attrs.style as "button" | "link";
+        }
+
+        if (node.attrs?.disableTracking) {
+          actionNode.disable_tracking = true;
         }
 
         actionNode.align = (node.attrs?.alignment as "left" | "center" | "right") || "center";


### PR DESCRIPTION
## Summary
Adds a per-element **Link tracking** toggle to the editor for text hyperlinks and action buttons, serialized as `disable_tracking` on the Elemental `link`/`action`. Pairs with the backend change that accepts and honors the flag.

- `disableTracking` attribute on the TipTap link mark (`Link.ts`) and button node (`Button.ts` / `Button.types.ts`)
- **"Link tracking"** toggle in `LinkForm`, `ButtonForm`, and the inline `LinkBubble` — default **on**; toggling **off** writes `disable_tracking: true`
- round-trip serialize/deserialize (`convertTiptapToElemental` / `convertElementalToTiptap`); emits `disable_tracking` only when true
- **gated on the workspace click-through tracking setting** via a new `linkTrackingEnabled` prop on `TemplateProvider`/`TemplateEditor` (synced into `linkTrackingEnabledAtom`, mirroring `variablesEnabledAtom`). When the workspace has tracking off, the toggle is **disabled + forced off + tooltip** ("Click-through tracking is turned off for this workspace"), without mutating the stored attribute.

## Tests
Serialize/deserialize (link + action), toggle on/off state, and the disabled/gated state. Full suite: **2748 pass**; `typecheck:src` + `lint:src` clean.

## Downstream (studio)
The host (studio) must pass `linkTrackingEnabled={useCttEnabled()}` into `<TemplateProvider>`. That requires this package to be published (canary) and the studio dependency bumped first — separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)