### PR TITLE
ci: disable full-cycle e2e tests on PRs (C-19520)

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -132,7 +132,12 @@ jobs:
           path: packages/react-designer/playwright-report/
           retention-days: 7
 
+  # Disabled on CI (C-19520): these tests hit the real Courier production API,
+  # which makes PR runs slow and flaky. Run them locally instead:
+  #   pnpm --filter @trycourier/react-designer test:e2e:fullcycle
+  # To re-enable, remove the `if: false` below.
   full-cycle-e2e-test:
+    if: false
     runs-on: macos-latest
     timeout-minutes: 25
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ pnpm --filter @trycourier/react-designer test:e2e:fullcycle
 - `button-padding.spec.ts` — padding consistency between Designer and email
 - `visual-snapshot.spec.ts` — pixel-level visual comparison per element
 
-**CI:** These tests run on every PR via the `full-cycle-e2e-test` job in `.github/workflows/check-pull-request.yml`. Credentials are stored as GitHub repository secrets (`COURIER_AUTH_TOKEN`, `VITE_JWT_TOKEN`, `VITE_API_URL`, `VITE_TENANT_ID`, `VITE_TEMPLATE_ID`).
+**CI:** Disabled. The `full-cycle-e2e-test` job in `.github/workflows/check-pull-request.yml` is gated behind `if: false` because it hits the real Courier production API (slow + flaky on PRs). Run these tests locally instead. To re-enable, remove the `if: false` — credentials are already stored as GitHub repository secrets (`COURIER_AUTH_TOKEN`, `VITE_JWT_TOKEN`, `VITE_API_URL`, `VITE_TENANT_ID`, `VITE_TEMPLATE_ID`).
 
 ## Build System
 


### PR DESCRIPTION
## Summary

Disables the `full-cycle-e2e-test` job in `.github/workflows/check-pull-request.yml`.

These tests drive the Designer against the **real Courier production API** (send + poll a live email), which makes PR runs slow and flaky. The job is gated behind `if: false` rather than deleted, so all steps and the GitHub secrets wiring stay intact.

## Changes

- `.github/workflows/check-pull-request.yml` — add `if: false` to `full-cycle-e2e-test`, plus a comment explaining why and how to re-enable.
- `CLAUDE.md` — update the "Full-Cycle E2E Tests" CI note to say the job is disabled and should be run locally.

`unit-test` and `e2e-test` are unaffected.

## Re-enabling

Remove the `if: false` line. No secret changes needed.

## Running locally

```bash
pnpm --filter @trycourier/react-designer test:e2e:fullcycle
```

## Note

If `full-cycle-e2e-test` is configured as a **required status check** on `main`, it needs to be removed from branch protection — a skipped job does not satisfy a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)