### PR TITLE
Fix stale dev API URLs in react-designer full-cycle env example

### DIFF
--- a/packages/react-designer/.env.fullcycle.example
+++ b/packages/react-designer/.env.fullcycle.example
@@ -14,12 +14,14 @@ COURIER_AUTH_TOKEN=""
 # ─── Send API ─────────────────────────────────────────────────
 # REST API base URL for /send, /messages, etc.
 # Default: https://api.courier.com (production)
-# Dev:     https://ud3bgeg0rb.execute-api.us-east-1.amazonaws.com/dev
+# Dev:     https://1m5q00wehc.execute-api.us-east-1.amazonaws.com/dev
 # VITE_SEND_API_URL="https://api.courier.com"
 
 # ─── Designer Config ─────────────────────────────────────────
 # These are used by the dev server (apps/editor-dev) to connect to the GraphQL API.
 # Copy from apps/editor-dev/.env or set your own.
+# Default: https://api.courier.com/client/q (production)
+# Dev:     https://1m5q00wehc.execute-api.us-east-1.amazonaws.com/dev/client/q
 VITE_API_URL="https://api.courier.com/client/q"
 VITE_TEMPLATE_ID="template-id"
 VITE_TENANT_ID="tenant-id"


### PR DESCRIPTION
The full-cycle E2E env example (`packages/react-designer/.env.fullcycle.example`) pointed its **Dev** hint at a defunct API Gateway id (`ud3bgeg0rb.execute-api…/dev`). Updated to the live dev backend (`1m5q00wehc.execute-api…/dev`) and added a matching dev hint for the Designer GraphQL URL (`…/dev/client/q`).

Comment-only change to the example file — no runtime impact. Spotted while wiring up dev testing for C-19268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)