### PR TITLE
fix(email): seed block and inline typography from the document base [C-19851]

### DIFF
--- a/.changeset/tidy-links-inherit.md
+++ b/.changeset/tidy-links-inherit.md
@@ -1,0 +1,13 @@
+---
+"@trycourier/react-designer": patch
+---
+
+Default link blue moves to `#007AFF` — the `a.link` fallback a host gets when it doesn't set `--brand-link-color`.
+
+Block-level and selected-text typography no longer render blank when unset. The font-size and line-spacing fields on text, quote and list blocks, the button's label size, and the bubble menu's text size now show the value the block or run **already renders at** — the document base, then the tier preset — and keep tracking the document base as it moves. Nothing is written to the block until the author types a *different* number, so an untouched block still carries no `font_size` / `line_height` of its own.
+
+The inherited value is resolved by a new `resolveInheritedTypography()`, which mirrors `getEmailEditorDocumentStyleVars` so a field cannot claim a size the canvas doesn't apply: the base font size reaches the body tiers only, the base line height reaches every tier, and a base font size with no base line height auto-scales the way the renderer does. For a text run the closest ancestor block that sets a size wins, matching the CSS-variable cascade the node views build.
+
+Two consequences worth knowing: typing the number a field was already showing is treated as "inherit" rather than pinning the block to it, and the bubble menu's size button now always shows a number instead of showing nothing when the run inherits.
+
+Authored text metrics are also capped — 128px font size, 160px line spacing — in every commit path (document, block and per-run), not just as the inputs' `max`, which a typed or pasted value bypasses. Over-limit values are capped rather than dropped.

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Email/EmailDocumentStyleFields.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Email/EmailDocumentStyleFields.tsx
@@ -9,6 +9,7 @@ import { Tooltip } from "@/components/ui/Tooltip";
 import { useAtomValue } from "jotai";
 import { emailFormattingEnabledAtom } from "../../store";
 import { Info } from "lucide-react";
+import { MAX_FONT_SIZE, MAX_LINE_HEIGHT } from "@/lib/constants/typography-limits";
 import type { useEmailDocumentStyles } from "../../hooks/useEmailDocumentStyles";
 
 export type EmailDocumentStyles = ReturnType<typeof useEmailDocumentStyles>;
@@ -190,6 +191,7 @@ export const EmailBaseTypographyFields = ({
             startAdornment={<FontSizeIcon className={ADORNMENT_ICON} />}
             type="number"
             min={0}
+            max={MAX_FONT_SIZE}
             aria-label="Base font size"
             data-testid="email-document-font-size"
             value={documentStyles.emailFontSizeValue}
@@ -205,6 +207,7 @@ export const EmailBaseTypographyFields = ({
             startAdornment={<LineHeightIcon className={ADORNMENT_ICON} />}
             type="number"
             min={0}
+            max={MAX_LINE_HEIGHT}
             aria-label="Base line spacing"
             data-testid="email-document-line-height"
             value={documentStyles.emailLineHeightValue}

--- a/packages/react-designer/src/components/TemplateEditor/emailFormattingGate.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/emailFormattingGate.test.tsx
@@ -56,6 +56,8 @@ describe("emailFormattingEnabled gate", () => {
       <TypographyFields
         fontSize={null}
         lineHeight={null}
+        inheritedFontSize={14}
+        inheritedLineHeight={18}
         onFontSizeChange={vi.fn()}
         onLineHeightChange={vi.fn()}
       />,

--- a/packages/react-designer/src/components/TemplateEditor/hooks/index.ts
+++ b/packages/react-designer/src/components/TemplateEditor/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./useDebouncedFlush";
 export * from "./useEmailBackgroundColors";
 export * from "./useEmailDocumentStyles";
+export * from "./useInheritedTypography";

--- a/packages/react-designer/src/components/TemplateEditor/hooks/useEmailDocumentStyles.ts
+++ b/packages/react-designer/src/components/TemplateEditor/hooks/useEmailDocumentStyles.ts
@@ -12,6 +12,11 @@ import {
   getEmailEditorDocumentStyleVars,
 } from "@/lib/constants/email-editor-tiptap-styles";
 import {
+  MAX_FONT_SIZE,
+  MAX_LINE_HEIGHT,
+  clampTypographyValue,
+} from "@/lib/constants/typography-limits";
+import {
   templateEditorContentAtom,
   emailPaddingAtom,
   emailFontSizeAtom,
@@ -189,7 +194,7 @@ export function useEmailDocumentStyles(options: UseEmailDocumentStylesOptions = 
 
   const handleFontSizeChange = useCallback(
     (value: number | null) => {
-      const next = value && value > 0 ? value : null;
+      const next = clampTypographyValue(value && value > 0 ? value : null, MAX_FONT_SIZE);
       setEmailFontSize(next);
       persist({ font_size: next === null ? undefined : `${next}px` });
     },
@@ -198,7 +203,7 @@ export function useEmailDocumentStyles(options: UseEmailDocumentStylesOptions = 
 
   const handleLineHeightChange = useCallback(
     (value: number | null) => {
-      const next = value && value > 0 ? value : null;
+      const next = clampTypographyValue(value && value > 0 ? value : null, MAX_LINE_HEIGHT);
       setEmailLineHeight(next);
       persist({ line_height: next === null ? undefined : `${next}px` });
     },

--- a/packages/react-designer/src/components/TemplateEditor/hooks/useInheritedTypography.ts
+++ b/packages/react-designer/src/components/TemplateEditor/hooks/useInheritedTypography.ts
@@ -1,0 +1,35 @@
+import { useAtomValue } from "jotai";
+import { useMemo } from "react";
+import {
+  resolveInheritedTypography,
+  type TextTier,
+} from "@/lib/constants/email-editor-tiptap-styles";
+import { emailFontSizeAtom, emailLineHeightAtom } from "../store";
+
+/**
+ * The font size and line spacing a block of `tier` renders at while it sets
+ * nothing of its own — the document base, then the tier preset.
+ *
+ * The block-level inputs show this as an editable placeholder: a real number the
+ * author can see and type over, that keeps tracking the document base until they
+ * do. Reading the document atoms here (rather than taking them as props) keeps
+ * every form in step with the Email styles panel without threading the values
+ * through four component trees.
+ *
+ * @see resolveInheritedTypography for how the cascade is resolved.
+ */
+export function useInheritedTypography({
+  tier,
+  isQuote = false,
+}: {
+  tier: TextTier;
+  isQuote?: boolean;
+}): { fontSize: number; lineHeight: number } {
+  const documentFontSize = useAtomValue(emailFontSizeAtom);
+  const documentLineHeight = useAtomValue(emailLineHeightAtom);
+
+  return useMemo(
+    () => resolveInheritedTypography({ tier, isQuote, documentFontSize, documentLineHeight }),
+    [tier, isQuote, documentFontSize, documentLineHeight]
+  );
+}

--- a/packages/react-designer/src/components/extensions/Blockquote/BlockquoteForm.tsx
+++ b/packages/react-designer/src/components/extensions/Blockquote/BlockquoteForm.tsx
@@ -20,6 +20,7 @@ import { ConditionsSection } from "../../ui/Conditions";
 import { TypographyFields } from "../shared/TypographyFields";
 import { useAtomValue } from "jotai";
 import { emailFormattingEnabledAtom } from "../../TemplateEditor/store";
+import { useInheritedTypography } from "../../TemplateEditor/hooks/useInheritedTypography";
 import type { ElementalIfCondition } from "@/types/conditions.types";
 
 interface BlockquoteFormProps {
@@ -53,6 +54,10 @@ export const BlockquoteForm = ({
   const fontSize = form.watch("fontSize");
   const lineHeight = form.watch("lineHeight");
 
+  // Quote body is a body tier, so it takes the document base, but off the
+  // quote presets rather than the paragraph ones.
+  const inherited = useInheritedTypography({ tier: "quote", isQuote: true });
+
   const commitTypography = (patch: { fontSize?: number | null; lineHeight?: number | null }) => {
     for (const [key, value] of Object.entries(patch)) {
       form.setValue(key as "fontSize" | "lineHeight", value);
@@ -78,6 +83,8 @@ export const BlockquoteForm = ({
             <TypographyFields
               fontSize={fontSize ?? null}
               lineHeight={lineHeight ?? null}
+              inheritedFontSize={inherited.fontSize}
+              inheritedLineHeight={inherited.lineHeight}
               onFontSizeChange={(value) => commitTypography({ fontSize: value })}
               onLineHeightChange={(value) => commitTypography({ lineHeight: value })}
             />

--- a/packages/react-designer/src/components/extensions/Button/ButtonForm.tsx
+++ b/packages/react-designer/src/components/extensions/Button/ButtonForm.tsx
@@ -38,10 +38,12 @@ import {
   updateButtonLabelAndContent,
 } from "./buttonUtils";
 import {
+  emailFontSizeAtom,
   emailFormattingEnabledAtom,
   linkTrackingEnabledAtom,
   setFormUpdating,
 } from "@/components/TemplateEditor/store";
+import { EMAIL_EDITOR_ACTION_FONT_SIZE_FALLBACK } from "@/lib/constants/email-editor-tiptap-styles";
 import { ConditionsSection } from "../../ui/Conditions";
 import { TypographyFields } from "../shared/TypographyFields";
 import type { ElementalIfCondition } from "@/types/conditions.types";
@@ -76,6 +78,15 @@ export const ButtonForm = ({ element, editor, hideCloseButton = false }: ButtonF
   });
 
   const fontSize = form.watch("fontSize");
+
+  /**
+   * What the label renders at while the button sets nothing: the document base,
+   * then the renderer's action fallback. Read off the action constant rather
+   * than the body tier — action-block.hbs has its own default, which today
+   * happens to match the paragraph preset.
+   */
+  const documentFontSize = useAtomValue(emailFontSizeAtom);
+  const inheritedFontSize = documentFontSize ?? parseFloat(EMAIL_EDITOR_ACTION_FONT_SIZE_FALLBACK);
 
   const buttonNodeIdRef = useRef<string | null>(element?.attrs.id || null);
   const buttonPosRef = useRef<number | null>(null);
@@ -249,6 +260,7 @@ export const ButtonForm = ({ element, editor, hideCloseButton = false }: ButtonF
             <Divider className="courier-mt-6 courier-mb-4" />
             <TypographyFields
               fontSize={fontSize ?? null}
+              inheritedFontSize={inheritedFontSize}
               showLineHeight={false}
               onFontSizeChange={(value) => {
                 form.setValue("fontSize", value);

--- a/packages/react-designer/src/components/extensions/List/ListForm.tsx
+++ b/packages/react-designer/src/components/extensions/List/ListForm.tsx
@@ -31,6 +31,7 @@ import { defaultListProps } from "./List";
 import { listSchema } from "./List.types";
 import { ConditionsSection } from "../../ui/Conditions";
 import { TypographyFields } from "../shared/TypographyFields";
+import { useInheritedTypography } from "../../TemplateEditor/hooks/useInheritedTypography";
 import type { ElementalIfCondition } from "@/types/conditions.types";
 
 interface ListFormProps {
@@ -128,6 +129,9 @@ export const ListForm = ({
   const fontSize = form.watch("fontSize");
   const lineHeight = form.watch("lineHeight");
 
+  // Items render as paragraphs, so the list follows the body tier.
+  const inherited = useInheritedTypography({ tier: "text" });
+
   const commitTypography = (patch: { fontSize?: number | null; lineHeight?: number | null }) => {
     for (const [key, value] of Object.entries(patch)) {
       form.setValue(key as "fontSize" | "lineHeight", value);
@@ -194,6 +198,8 @@ export const ListForm = ({
                 <TypographyFields
                   fontSize={fontSize ?? null}
                   lineHeight={lineHeight ?? null}
+                  inheritedFontSize={inherited.fontSize}
+                  inheritedLineHeight={inherited.lineHeight}
                   onFontSizeChange={(value) => commitTypography({ fontSize: value })}
                   onLineHeightChange={(value) => commitTypography({ lineHeight: value })}
                 />

--- a/packages/react-designer/src/components/extensions/TextBlock/TextBlockForm.tsx
+++ b/packages/react-designer/src/components/extensions/TextBlock/TextBlockForm.tsx
@@ -27,6 +27,8 @@ import { ConditionsSection } from "../../ui/Conditions";
 import { TypographyFields } from "../shared/TypographyFields";
 import { useAtomValue } from "jotai";
 import { emailFormattingEnabledAtom } from "../../TemplateEditor/store";
+import { useInheritedTypography } from "../../TemplateEditor/hooks/useInheritedTypography";
+import { tierForTextBlock } from "@/lib/constants/email-editor-tiptap-styles";
 import type { ElementalIfCondition } from "@/types/conditions.types";
 
 interface TextBlockFormProps {
@@ -56,6 +58,15 @@ export const TextBlockForm = ({ element, editor, hideCloseButton = false }: Text
   const fontSize = form.watch("fontSize");
   const lineHeight = form.watch("lineHeight");
 
+  // Headings keep their preset size, so the tier decides how much of the
+  // document base reaches this block — see resolveInheritedTypography.
+  const inherited = useInheritedTypography({
+    tier: tierForTextBlock(
+      element?.type.name ?? "paragraph",
+      element?.attrs?.level as number | undefined
+    ),
+  });
+
   const commitTypography = (patch: { fontSize?: number | null; lineHeight?: number | null }) => {
     for (const [key, value] of Object.entries(patch)) {
       form.setValue(key as "fontSize" | "lineHeight", value);
@@ -81,6 +92,8 @@ export const TextBlockForm = ({ element, editor, hideCloseButton = false }: Text
             <TypographyFields
               fontSize={fontSize ?? null}
               lineHeight={lineHeight ?? null}
+              inheritedFontSize={inherited.fontSize}
+              inheritedLineHeight={inherited.lineHeight}
               onFontSizeChange={(value) => commitTypography({ fontSize: value })}
               onLineHeightChange={(value) => commitTypography({ lineHeight: value })}
             />

--- a/packages/react-designer/src/components/extensions/shared/TypographyFields.test.tsx
+++ b/packages/react-designer/src/components/extensions/shared/TypographyFields.test.tsx
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import type { ReactNode } from "react";
+import { emailFormattingEnabledAtom } from "@/components/TemplateEditor/store";
+import { MAX_FONT_SIZE, MAX_LINE_HEIGHT } from "@/lib/constants/typography-limits";
+import { TypographyFields } from "./TypographyFields";
+
+/**
+ * The block-level fields behave as an *editable placeholder*: they show the size
+ * the block already renders at (document base, then tier preset), keep tracking
+ * it, and only write to the block once the author types a different number.
+ */
+const renderFields = (ui: ReactNode) => {
+  const store = createStore();
+  store.set(emailFormattingEnabledAtom, true);
+  render(<Provider store={store}>{ui}</Provider>);
+};
+
+const fontSizeInput = () => screen.getByTestId("typography-font-size") as HTMLInputElement;
+const lineHeightInput = () => screen.getByTestId("typography-line-height") as HTMLInputElement;
+
+describe("TypographyFields", () => {
+  it("seeds both fields from the inherited values when the block sets nothing", () => {
+    renderFields(
+      <TypographyFields
+        fontSize={null}
+        lineHeight={null}
+        inheritedFontSize={13}
+        inheritedLineHeight={15}
+        onFontSizeChange={vi.fn()}
+        onLineHeightChange={vi.fn()}
+      />
+    );
+
+    expect(fontSizeInput().value).toBe("13");
+    expect(lineHeightInput().value).toBe("15");
+  });
+
+  it("shows the block's own override in place of the inherited value", () => {
+    renderFields(
+      <TypographyFields
+        fontSize={20}
+        lineHeight={24}
+        inheritedFontSize={13}
+        inheritedLineHeight={15}
+        onFontSizeChange={vi.fn()}
+        onLineHeightChange={vi.fn()}
+      />
+    );
+
+    expect(fontSizeInput().value).toBe("20");
+    expect(lineHeightInput().value).toBe("24");
+  });
+
+  it("follows the document base as it moves, without writing to the block", () => {
+    const onFontSizeChange = vi.fn();
+    const onLineHeightChange = vi.fn();
+    const store = createStore();
+    store.set(emailFormattingEnabledAtom, true);
+
+    const fields = (inheritedFontSize: number, inheritedLineHeight: number) => (
+      <Provider store={store}>
+        <TypographyFields
+          fontSize={null}
+          lineHeight={null}
+          inheritedFontSize={inheritedFontSize}
+          inheritedLineHeight={inheritedLineHeight}
+          onFontSizeChange={onFontSizeChange}
+          onLineHeightChange={onLineHeightChange}
+        />
+      </Provider>
+    );
+
+    const { rerender } = render(fields(13, 15));
+    rerender(fields(12, 13));
+
+    expect(fontSizeInput().value).toBe("12");
+    expect(lineHeightInput().value).toBe("13");
+    expect(onFontSizeChange).not.toHaveBeenCalled();
+    expect(onLineHeightChange).not.toHaveBeenCalled();
+  });
+
+  it("writes the override once the author types a different number", () => {
+    const onFontSizeChange = vi.fn();
+    renderFields(
+      <TypographyFields
+        fontSize={null}
+        lineHeight={null}
+        inheritedFontSize={13}
+        inheritedLineHeight={15}
+        onFontSizeChange={onFontSizeChange}
+        onLineHeightChange={vi.fn()}
+      />
+    );
+
+    fireEvent.change(fontSizeInput(), { target: { value: "20" } });
+    expect(onFontSizeChange).toHaveBeenCalledWith(20);
+  });
+
+  // Typing the number the field was already showing is not a change: persisting
+  // it would pin the block so it stopped tracking the document base.
+  it("treats the inherited value as unset rather than pinning it", () => {
+    const onFontSizeChange = vi.fn();
+    renderFields(
+      <TypographyFields
+        fontSize={20}
+        lineHeight={null}
+        inheritedFontSize={13}
+        inheritedLineHeight={15}
+        onFontSizeChange={onFontSizeChange}
+        onLineHeightChange={vi.fn()}
+      />
+    );
+
+    fireEvent.change(fontSizeInput(), { target: { value: "13" } });
+    expect(onFontSizeChange).toHaveBeenCalledWith(null);
+  });
+
+  it("drops the override when the field is cleared", () => {
+    const onLineHeightChange = vi.fn();
+    renderFields(
+      <TypographyFields
+        fontSize={null}
+        lineHeight={24}
+        inheritedFontSize={13}
+        inheritedLineHeight={15}
+        onFontSizeChange={vi.fn()}
+        onLineHeightChange={onLineHeightChange}
+      />
+    );
+
+    fireEvent.change(lineHeightInput(), { target: { value: "" } });
+    expect(onLineHeightChange).toHaveBeenCalledWith(null);
+  });
+
+  it("does not fire for a no-op change on an already-inheriting field", () => {
+    const onFontSizeChange = vi.fn();
+    renderFields(
+      <TypographyFields
+        fontSize={null}
+        lineHeight={null}
+        inheritedFontSize={13}
+        inheritedLineHeight={15}
+        onFontSizeChange={onFontSizeChange}
+        onLineHeightChange={vi.fn()}
+      />
+    );
+
+    fireEvent.change(fontSizeInput(), { target: { value: "" } });
+    fireEvent.change(fontSizeInput(), { target: { value: "13" } });
+    expect(onFontSizeChange).not.toHaveBeenCalled();
+  });
+
+  // `max` only blocks the spinner and form validation, so a typed or pasted
+  // value still has to be capped in the commit path.
+  it("caps a typed value at the ceiling instead of dropping it", () => {
+    const onFontSizeChange = vi.fn();
+    const onLineHeightChange = vi.fn();
+    renderFields(
+      <TypographyFields
+        fontSize={null}
+        lineHeight={null}
+        inheritedFontSize={13}
+        inheritedLineHeight={15}
+        onFontSizeChange={onFontSizeChange}
+        onLineHeightChange={onLineHeightChange}
+      />
+    );
+
+    fireEvent.change(fontSizeInput(), { target: { value: "2000" } });
+    fireEvent.change(lineHeightInput(), { target: { value: "2000" } });
+
+    expect(onFontSizeChange).toHaveBeenCalledWith(MAX_FONT_SIZE);
+    expect(onLineHeightChange).toHaveBeenCalledWith(MAX_LINE_HEIGHT);
+    expect(fontSizeInput().max).toBe(String(MAX_FONT_SIZE));
+    expect(lineHeightInput().max).toBe(String(MAX_LINE_HEIGHT));
+  });
+
+  it("hides the line spacing field for button labels", () => {
+    renderFields(
+      <TypographyFields
+        fontSize={null}
+        inheritedFontSize={14}
+        showLineHeight={false}
+        onFontSizeChange={vi.fn()}
+      />
+    );
+
+    expect(fontSizeInput().value).toBe("14");
+    expect(screen.queryByTestId("typography-line-height")).not.toBeInTheDocument();
+  });
+});

--- a/packages/react-designer/src/components/extensions/shared/TypographyFields.tsx
+++ b/packages/react-designer/src/components/extensions/shared/TypographyFields.tsx
@@ -4,6 +4,11 @@ import { Tooltip } from "@/components/ui/Tooltip";
 import { Info } from "lucide-react";
 import { useAtomValue } from "jotai";
 import { emailFormattingEnabledAtom } from "@/components/TemplateEditor/store";
+import {
+  MAX_FONT_SIZE,
+  MAX_LINE_HEIGHT,
+  clampTypographyValue,
+} from "@/lib/constants/typography-limits";
 
 /**
  * Both icons are drawn on a 28-unit viewBox (Icon derives the viewBox from
@@ -12,34 +17,75 @@ import { emailFormattingEnabledAtom } from "@/components/TemplateEditor/store";
  */
 const ADORNMENT_ICON = "courier-w-4 courier-h-4";
 
-interface TypographyFieldsProps {
+/**
+ * Line spacing is all-or-nothing: a caller that shows the field owes both the
+ * current override and the inherited value it falls back to, so the field can
+ * never render an empty box. Elemental has no `line_height` on action nodes, so
+ * the button form opts out with `showLineHeight: false` instead.
+ */
+type LineHeightProps =
+  | {
+      showLineHeight?: true;
+      lineHeight?: number | null;
+      inheritedLineHeight: number;
+      onLineHeightChange: (value: number | null) => void;
+    }
+  | {
+      showLineHeight: false;
+      lineHeight?: never;
+      inheritedLineHeight?: never;
+      onLineHeightChange?: never;
+    };
+
+type TypographyFieldsProps = LineHeightProps & {
   /** Current px override, or null when the block inherits. */
   fontSize?: number | null;
-  lineHeight?: number | null;
+  /**
+   * What the block renders at while it sets nothing — the document base, then
+   * the tier preset. Shown in the field as an editable placeholder, so the
+   * author sees the real sizing instead of an empty box.
+   */
+  inheritedFontSize: number;
   /** Called with null when the field is cleared, i.e. back to inheriting. */
   onFontSizeChange: (value: number | null) => void;
-  onLineHeightChange?: (value: number | null) => void;
-  /** Elemental has no `line_height` on action nodes, so buttons hide it. */
-  showLineHeight?: boolean;
   className?: string;
-}
+};
 
-const toValue = (raw: string): number | null => {
+/**
+ * The value to store for what the author typed.
+ *
+ * Empty means "inherit", and so does the inherited value itself: typing the
+ * number the field was already showing is not a change, and persisting it would
+ * silently pin the block so it stopped tracking the document base. Clearing the
+ * field and retyping the base value therefore both land on the same state.
+ *
+ * Anything above `max` is capped rather than rejected, so a typed or pasted 2000
+ * lands on the ceiling instead of being dropped as if the field were empty.
+ */
+const toValue = (raw: string, inherited: number, max: number): number | null => {
   if (raw.trim() === "") return null;
   const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  const capped = clampTypographyValue(parsed, max);
+  return capped === inherited ? null : capped;
 };
 
 /**
  * Font size / line spacing overrides, in px.
  *
- * Empty means inherit — the document-level base, then the tier preset — which is
- * how the renderer resolves a missing `font_size` / `line_height`. Overrides are
- * per-block defaults and don't stick to the next block of the same kind.
+ * The fields are seeded with the value the block already renders at — the
+ * document-level base, then the tier preset — and that seed keeps tracking the
+ * document base as it changes. Nothing is written to the block until the author
+ * types a *different* number, so an untouched block carries no `font_size` /
+ * `line_height` of its own. Clearing a field drops the override again.
+ *
+ * Overrides are per-block and don't stick to the next block of the same kind.
  */
 export const TypographyFields = ({
   fontSize,
   lineHeight,
+  inheritedFontSize,
+  inheritedLineHeight,
   onFontSizeChange,
   onLineHeightChange,
   showLineHeight = true,
@@ -57,8 +103,8 @@ export const TypographyFields = ({
         <Tooltip
           title={
             showLineHeight
-              ? "Font size and line spacing in pixels. Leave empty to inherit the email's base values. Keep line spacing at or above the font size so text doesn't overlap."
-              : "Button label size in pixels. Leave empty to inherit the email's base font size."
+              ? "Font size and line spacing in pixels. These follow the email's base values until you change them — clear a field to follow the base again. Keep line spacing at or above the font size so text doesn't overlap."
+              : "Button label size in pixels. Follows the email's base font size until you change it — clear it to follow the base again."
           }
           tippyOptions={{ maxWidth: 260 }}
         >
@@ -71,22 +117,34 @@ export const TypographyFields = ({
             startAdornment={<FontSizeIcon className={ADORNMENT_ICON} />}
             type="number"
             min={0}
+            max={MAX_FONT_SIZE}
             aria-label="Font size"
             data-testid="typography-font-size"
-            value={fontSize ?? ""}
-            onChange={(e) => onFontSizeChange(toValue(e.target.value))}
+            value={fontSize ?? inheritedFontSize}
+            onChange={(e) => {
+              const next = toValue(e.target.value, inheritedFontSize, MAX_FONT_SIZE);
+              // Skip the no-op so clearing an already-inheriting field doesn't
+              // queue an autosave for a change that isn't one.
+              if (next === (fontSize ?? null)) return;
+              onFontSizeChange(next);
+            }}
           />
         </div>
-        {showLineHeight && onLineHeightChange && (
+        {showLineHeight && onLineHeightChange && inheritedLineHeight !== undefined && (
           <div className="courier-flex-1">
             <Input
               startAdornment={<LineHeightIcon className={ADORNMENT_ICON} />}
               type="number"
               min={0}
+              max={MAX_LINE_HEIGHT}
               aria-label="Line spacing"
               data-testid="typography-line-height"
-              value={lineHeight ?? ""}
-              onChange={(e) => onLineHeightChange(toValue(e.target.value))}
+              value={lineHeight ?? inheritedLineHeight}
+              onChange={(e) => {
+                const next = toValue(e.target.value, inheritedLineHeight, MAX_LINE_HEIGHT);
+                if (next === (lineHeight ?? null)) return;
+                onLineHeightChange(next);
+              }}
             />
           </div>
         )}

--- a/packages/react-designer/src/components/typography.css
+++ b/packages/react-designer/src/components/typography.css
@@ -56,9 +56,9 @@
     @apply courier-no-underline;
     /* Brand link color when a host sets --brand-link-color (e.g. studio's email
        preview); overridable by a per-link textStyle color mark (inline span
-       wins). Fallback keeps the original blue-700 so consumers that don't set
-       the variable are unchanged. */
-    color: var(--brand-link-color, #1d4ed8);
+       wins). The fallback is the product's default link blue, so a host that
+       doesn't set the variable still gets the same blue studio shows. */
+    color: var(--brand-link-color, #007aff);
   }
 
   mark {

--- a/packages/react-designer/src/components/ui/TextMenu/TextMenu.tsx
+++ b/packages/react-designer/src/components/ui/TextMenu/TextMenu.tsx
@@ -296,6 +296,7 @@ export const TextMenu = ({ editor, config }: TextMenuProps) => {
         <FontSizeButton
           key="font-size"
           fontSize={states.currentFontSize}
+          inheritedFontSize={states.inheritedFontSize}
           onChange={commands.onSetFontSize}
           containerRef={toolbarRef}
         />

--- a/packages/react-designer/src/components/ui/TextMenu/components/FontSizeButton.test.tsx
+++ b/packages/react-designer/src/components/ui/TextMenu/components/FontSizeButton.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import type { ReactNode } from "react";
+import { emailFormattingEnabledAtom } from "@/components/TemplateEditor/store";
+import { MAX_FONT_SIZE } from "@/lib/constants/typography-limits";
+import { FontSizeButton } from "./FontSizeButton";
+
+/**
+ * The per-run size control behaves as an editable placeholder, like the
+ * block-level fields: it shows what the selection already renders at and only
+ * writes a `font_size` mark once the author types a different number.
+ */
+const renderButton = (ui: ReactNode) => {
+  const store = createStore();
+  store.set(emailFormattingEnabledAtom, true);
+  render(<Provider store={store}>{ui}</Provider>);
+};
+
+const openPopover = () => fireEvent.click(screen.getByTestId("text-menu-font-size"));
+const sizeInput = () => screen.getByLabelText("Text size") as HTMLInputElement;
+
+describe("FontSizeButton", () => {
+  it("shows the inherited size on the trigger when the run sets nothing", () => {
+    renderButton(<FontSizeButton inheritedFontSize={13} onChange={vi.fn()} />);
+
+    expect(screen.getByTestId("text-menu-font-size")).toHaveTextContent("13");
+  });
+
+  it("shows the run's own size in place of the inherited one", () => {
+    renderButton(<FontSizeButton fontSize={20} inheritedFontSize={13} onChange={vi.fn()} />);
+
+    expect(screen.getByTestId("text-menu-font-size")).toHaveTextContent("20");
+  });
+
+  it("seeds the input with the inherited size", () => {
+    renderButton(<FontSizeButton inheritedFontSize={13} onChange={vi.fn()} />);
+
+    openPopover();
+    expect(sizeInput().value).toBe("13");
+  });
+
+  it("writes the mark once the author commits a different size", () => {
+    const onChange = vi.fn();
+    renderButton(<FontSizeButton inheritedFontSize={13} onChange={onChange} />);
+
+    openPopover();
+    fireEvent.change(sizeInput(), { target: { value: "20" } });
+    fireEvent.blur(sizeInput());
+
+    expect(onChange).toHaveBeenCalledWith(20);
+  });
+
+  // Opening and dismissing the popover must not push a transaction — that would
+  // pin the run at its inherited size and steal the caret.
+  it("does not write anything when the seeded value is committed unchanged", () => {
+    const onChange = vi.fn();
+    renderButton(<FontSizeButton inheritedFontSize={13} onChange={onChange} />);
+
+    openPopover();
+    fireEvent.blur(sizeInput());
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("drops the mark when the author retypes the inherited size", () => {
+    const onChange = vi.fn();
+    renderButton(<FontSizeButton fontSize={20} inheritedFontSize={13} onChange={onChange} />);
+
+    openPopover();
+    fireEvent.change(sizeInput(), { target: { value: "13" } });
+    fireEvent.blur(sizeInput());
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("drops the mark when the field is cleared", () => {
+    const onChange = vi.fn();
+    renderButton(<FontSizeButton fontSize={20} inheritedFontSize={13} onChange={onChange} />);
+
+    openPopover();
+    fireEvent.change(sizeInput(), { target: { value: "" } });
+    fireEvent.blur(sizeInput());
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("caps a typed value at the ceiling", () => {
+    const onChange = vi.fn();
+    renderButton(<FontSizeButton inheritedFontSize={13} onChange={onChange} />);
+
+    openPopover();
+    fireEvent.change(sizeInput(), { target: { value: "2000" } });
+    fireEvent.blur(sizeInput());
+
+    expect(onChange).toHaveBeenCalledWith(MAX_FONT_SIZE);
+    expect(sizeInput().max).toBe(String(MAX_FONT_SIZE));
+  });
+});

--- a/packages/react-designer/src/components/ui/TextMenu/components/FontSizeButton.tsx
+++ b/packages/react-designer/src/components/ui/TextMenu/components/FontSizeButton.tsx
@@ -5,10 +5,17 @@ import { FontSizeIcon } from "@/components/ui-kit/Icon";
 import { Tooltip } from "../../Tooltip";
 import { useAtomValue } from "jotai";
 import { emailFormattingEnabledAtom } from "@/components/TemplateEditor/store";
+import { MAX_FONT_SIZE, clampTypographyValue } from "@/lib/constants/typography-limits";
 
 interface FontSizeButtonProps {
   /** px size on the selected run, or undefined when it inherits. */
   fontSize?: number;
+  /**
+   * What the run renders at while `fontSize` is unset — the closest sized
+   * ancestor block, then the document base, then the tier preset. Shown on the
+   * trigger and seeded into the input, so the control is never blank.
+   */
+  inheritedFontSize?: number;
   onChange: (fontSize: number | null) => void;
   /**
    * The toolbar element, used as the popover's portal container.
@@ -24,83 +31,97 @@ interface FontSizeButtonProps {
 
 /**
  * Per-run font size for the current text selection (Elemental `font_size` on a
- * `string`/`link` element). Clearing the field drops the override so the run
- * falls back to its block, then the document base.
+ * `string`/`link` element).
+ *
+ * The field is seeded with the size the run already renders at — its block, then
+ * the document base — and that seed keeps tracking those as they change. Nothing
+ * is written to the run until the author types a *different* number, so an
+ * untouched selection carries no `font_size`. Clearing the field, or retyping the
+ * inherited size, drops the override again.
  */
-export const FontSizeButton = memo(({ fontSize, onChange, containerRef }: FontSizeButtonProps) => {
-  const emailFormattingEnabled = useAtomValue(emailFormattingEnabledAtom);
-  const [open, setOpen] = useState(false);
-  const [draft, setDraft] = useState<string>(fontSize ? String(fontSize) : "");
+export const FontSizeButton = memo(
+  ({ fontSize, inheritedFontSize, onChange, containerRef }: FontSizeButtonProps) => {
+    const emailFormattingEnabled = useAtomValue(emailFormattingEnabledAtom);
+    const [open, setOpen] = useState(false);
+    /** The size on show: the run's own override, else what it inherits. */
+    const effectiveFontSize = fontSize ?? inheritedFontSize;
+    const [draft, setDraft] = useState<string>(effectiveFontSize ? String(effectiveFontSize) : "");
 
-  // Re-seed when the selection moves to a run with a different size
-  useEffect(() => {
-    setDraft(fontSize ? String(fontSize) : "");
-  }, [fontSize]);
+    // Re-seed when the selection moves to a run that renders at a different size
+    useEffect(() => {
+      setDraft(effectiveFontSize ? String(effectiveFontSize) : "");
+    }, [effectiveFontSize]);
 
-  const commit = useCallback(
-    (raw: string) => {
-      const parsed = Number(raw);
-      const next = raw.trim() === "" || !Number.isFinite(parsed) || parsed <= 0 ? null : parsed;
+    const commit = useCallback(
+      (raw: string) => {
+        const parsed = Number(raw);
+        const typed = raw.trim() === "" || !Number.isFinite(parsed) || parsed <= 0 ? null : parsed;
+        // Typing the inherited size is not a change: persisting it would pin the
+        // run so it stopped tracking the block and document base.
+        const capped = clampTypographyValue(typed, MAX_FONT_SIZE);
+        const next = capped === inheritedFontSize ? null : capped;
 
-      // Setting the mark refocuses the editor, so skip the no-op case —
-      // otherwise merely opening and dismissing the popover would push a
-      // transaction and steal the caret.
-      if (next === (fontSize ?? null)) return;
+        // Setting the mark refocuses the editor, so skip the no-op case —
+        // otherwise merely opening and dismissing the popover would push a
+        // transaction and steal the caret.
+        if (next === (fontSize ?? null)) return;
 
-      onChange(next);
-    },
-    [onChange, fontSize]
-  );
+        onChange(next);
+      },
+      [onChange, fontSize, inheritedFontSize]
+    );
 
-  // After the hooks above, so the early return does not change their order.
-  if (!emailFormattingEnabled) return null;
+    // After the hooks above, so the early return does not change their order.
+    if (!emailFormattingEnabled) return null;
 
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <Tooltip title="Text size">
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            data-testid="text-menu-font-size"
-            className="courier-gap-1 courier-min-w-[2rem] courier-w-auto courier-inline-flex courier-items-center courier-justify-center courier-whitespace-nowrap courier-rounded-md courier-text-sm courier-font-medium courier-transition-colors focus-visible:courier-outline-none disabled:courier-pointer-events-none disabled:courier-opacity-50 hover:courier-bg-accent hover:courier-text-accent-foreground courier-h-8 courier-px-2 courier-text-neutral-600 dark:courier-text-neutral-300"
-            // Keep the editor selection intact when opening the popover.
-            onMouseDown={(e) => e.preventDefault()}
-          >
-            {/* 28-unit viewBox scaled with CSS (see Icon) so it matches the
+    return (
+      <Popover open={open} onOpenChange={setOpen}>
+        <Tooltip title="Text size">
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              data-testid="text-menu-font-size"
+              className="courier-gap-1 courier-min-w-[2rem] courier-w-auto courier-inline-flex courier-items-center courier-justify-center courier-whitespace-nowrap courier-rounded-md courier-text-sm courier-font-medium courier-transition-colors focus-visible:courier-outline-none disabled:courier-pointer-events-none disabled:courier-opacity-50 hover:courier-bg-accent hover:courier-text-accent-foreground courier-h-8 courier-px-2 courier-text-neutral-600 dark:courier-text-neutral-300"
+              // Keep the editor selection intact when opening the popover.
+              onMouseDown={(e) => e.preventDefault()}
+            >
+              {/* 28-unit viewBox scaled with CSS (see Icon) so it matches the
                   16px lucide icons in the rest of the toolbar. */}
-            <FontSizeIcon className="courier-w-4 courier-h-4" />
-            {fontSize ? (
-              <span className="courier-text-xs courier-leading-none">{fontSize}</span>
-            ) : null}
-          </button>
-        </PopoverTrigger>
-      </Tooltip>
-      <PopoverContent
-        portalProps={{ container: containerRef?.current || undefined }}
-        className="courier-w-[190px]"
-      >
-        <p className="courier-text-xs courier-text-muted-foreground courier-mb-2">
-          Size in pixels. Leave empty to inherit.
-        </p>
-        <Input
-          autoFocus
-          type="number"
-          min={0}
-          aria-label="Text size"
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onBlur={() => commit(draft)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              commit(draft);
-              setOpen(false);
-            }
-          }}
-        />
-      </PopoverContent>
-    </Popover>
-  );
-});
+              <FontSizeIcon className="courier-w-4 courier-h-4" />
+              {effectiveFontSize ? (
+                <span className="courier-text-xs courier-leading-none">{effectiveFontSize}</span>
+              ) : null}
+            </button>
+          </PopoverTrigger>
+        </Tooltip>
+        <PopoverContent
+          portalProps={{ container: containerRef?.current || undefined }}
+          className="courier-w-[190px]"
+        >
+          <p className="courier-text-xs courier-text-muted-foreground courier-mb-2">
+            Size in pixels. Follows the block and email base until you change it.
+          </p>
+          <Input
+            autoFocus
+            type="number"
+            min={0}
+            max={MAX_FONT_SIZE}
+            aria-label="Text size"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={() => commit(draft)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                commit(draft);
+                setOpen(false);
+              }
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+    );
+  }
+);
 
 FontSizeButton.displayName = "FontSizeButton";

--- a/packages/react-designer/src/components/ui/TextMenu/hooks/resolveSelectionFontSize.test.ts
+++ b/packages/react-designer/src/components/ui/TextMenu/hooks/resolveSelectionFontSize.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/react";
+import { Document } from "@tiptap/extension-document";
+import { Paragraph } from "@tiptap/extension-paragraph";
+import { Text } from "@tiptap/extension-text";
+import { Heading } from "@tiptap/extension-heading";
+import { Blockquote } from "@tiptap/extension-blockquote";
+import { TextSelection } from "prosemirror-state";
+import { resolveSelectionFontSize } from "./useTextmenuStates";
+
+/**
+ * Stand-ins for the real block extensions: only the `fontSize` attribute the
+ * walk reads matters here, and plain tiptap nodes keep the test free of the
+ * node-view mocking the full extension kit needs.
+ */
+const withFontSize = <T extends { extend: (config: object) => unknown }>(node: T) =>
+  node.extend({
+    addAttributes(this: { parent?: () => object }) {
+      // Keep the node's own attributes — Heading's `level` decides its tier.
+      return { ...this.parent?.(), fontSize: { default: null } };
+    },
+  });
+
+const EXTENSIONS = [
+  Document,
+  Text,
+  withFontSize(Paragraph),
+  withFontSize(Heading),
+  withFontSize(Blockquote),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+] as any[];
+
+/** An editor with the caret inside the first text node of the document. */
+const editorWith = (content: object) => {
+  const editor = new Editor({ extensions: EXTENSIONS, content });
+  let textPos: number | null = null;
+  editor.state.doc.descendants((node, pos) => {
+    if (textPos === null && node.isText) textPos = pos;
+  });
+  editor.view.dispatch(
+    editor.state.tr.setSelection(TextSelection.create(editor.state.doc, textPos ?? 1))
+  );
+  return editor;
+};
+
+const paragraph = (attrs: Record<string, unknown> = {}) => ({
+  type: "doc",
+  content: [{ type: "paragraph", attrs, content: [{ type: "text", text: "hello" }] }],
+});
+
+describe("resolveSelectionFontSize", () => {
+  it("falls back to the tier preset with nothing set anywhere", () => {
+    expect(resolveSelectionFontSize(editorWith(paragraph()), null, null)).toBe(14);
+  });
+
+  it("takes the document base when the block sets nothing", () => {
+    expect(resolveSelectionFontSize(editorWith(paragraph()), 13, 15)).toBe(13);
+  });
+
+  it("prefers the block's own size over the document base", () => {
+    expect(resolveSelectionFontSize(editorWith(paragraph({ fontSize: 20 })), 13, 15)).toBe(20);
+  });
+
+  it("uses the heading preset, which the document base never reaches", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        { type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "hello" }] },
+      ],
+    };
+    expect(resolveSelectionFontSize(editorWith(doc), 13, 15)).toBe(32);
+  });
+
+  // Each block sets the tier variable on its own wrapper, so the closest
+  // ancestor that sets a size is the one the canvas actually applies.
+  it("reports the quote's size for an unsized paragraph inside it", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          attrs: { fontSize: 22 },
+          content: [{ type: "paragraph", content: [{ type: "text", text: "hello" }] }],
+        },
+      ],
+    };
+    expect(resolveSelectionFontSize(editorWith(doc), 13, 15)).toBe(22);
+  });
+
+  it("lets the inner paragraph's own size win over the quote's", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          attrs: { fontSize: 22 },
+          content: [
+            {
+              type: "paragraph",
+              attrs: { fontSize: 30 },
+              content: [{ type: "text", text: "hello" }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(resolveSelectionFontSize(editorWith(doc), 13, 15)).toBe(30);
+  });
+
+  it("resolves an unsized quote off the quote preset, then the document base", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [{ type: "paragraph", content: [{ type: "text", text: "hello" }] }],
+        },
+      ],
+    };
+    expect(resolveSelectionFontSize(editorWith(doc), null, null)).toBe(14);
+    expect(resolveSelectionFontSize(editorWith(doc), 13, 15)).toBe(13);
+  });
+});

--- a/packages/react-designer/src/components/ui/TextMenu/hooks/useTextmenuStates.ts
+++ b/packages/react-designer/src/components/ui/TextMenu/hooks/useTextmenuStates.ts
@@ -6,11 +6,66 @@ import { channelAtom } from "@/store";
 import { pendingLinkAtom, selectedNodeAtom } from "../store";
 import { isBrandColorRef } from "@/lib/utils/brandColors";
 import { parsePxValue } from "@/lib/utils/cssValues";
+import { emailFontSizeAtom, emailLineHeightAtom } from "@/components/TemplateEditor/store";
+import {
+  resolveInheritedTypography,
+  tierForTextBlock,
+  type TextTier,
+} from "@/lib/constants/email-editor-tiptap-styles";
+
+/**
+ * The px size the selection renders at while the run carries no `font_size` of
+ * its own: the closest ancestor block that sets one, then the document base,
+ * then the tier preset.
+ *
+ * The bubble menu shows this as an editable placeholder, so the size control is
+ * never blank. "Closest ancestor wins" is the same order the canvas resolves in
+ * — each block sets the tier CSS variable on its own wrapper — so a paragraph
+ * inside a sized quote reports the quote's size.
+ *
+ * Exported for tests: the walk is the only part of this hook that isn't a thin
+ * wrapper over `editor.isActive`.
+ */
+export const resolveSelectionFontSize = (
+  editor: Editor,
+  documentFontSize: number | null,
+  documentLineHeight: number | null
+): number => {
+  const { $from } = editor.state.selection;
+
+  let blockFontSize: number | null = null;
+  let tier: TextTier | null = null;
+  let isQuote = false;
+
+  for (let depth = $from.depth; depth >= 0; depth--) {
+    const node = $from.node(depth);
+    if (node.type.name === "blockquote") isQuote = true;
+
+    const nodeFontSize = node.attrs?.fontSize;
+    if (blockFontSize === null && typeof nodeFontSize === "number" && nodeFontSize > 0) {
+      blockFontSize = nodeFontSize;
+    }
+    if (tier === null && (node.type.name === "paragraph" || node.type.name === "heading")) {
+      tier = tierForTextBlock(node.type.name, node.attrs?.level as number | undefined);
+    }
+  }
+
+  if (blockFontSize !== null) return blockFontSize;
+
+  return resolveInheritedTypography({
+    tier: tier ?? (isQuote ? "quote" : "text"),
+    isQuote,
+    documentFontSize,
+    documentLineHeight,
+  }).fontSize;
+};
 
 export const useTextmenuStates = (editor: Editor | null) => {
   const selectedNode = useAtomValue(selectedNodeAtom);
   const channel = useAtomValue(channelAtom);
   const pendingLink = useAtomValue(pendingLinkAtom);
+  const documentFontSize = useAtomValue(emailFontSizeAtom);
+  const documentLineHeight = useAtomValue(emailLineHeightAtom);
 
   const [states, setStates] = useState({
     isBold: false,
@@ -28,6 +83,8 @@ export const useTextmenuStates = (editor: Editor | null) => {
     isHeading: false,
     currentColor: undefined as string | undefined,
     currentFontSize: undefined as number | undefined,
+    /** What the selection renders at while `currentFontSize` is unset. */
+    inheritedFontSize: undefined as number | undefined,
   });
 
   const updateStates = useCallback(() => {
@@ -51,6 +108,7 @@ export const useTextmenuStates = (editor: Editor | null) => {
         isHeading: false,
         currentColor: undefined,
         currentFontSize: undefined,
+        inheritedFontSize: undefined,
       });
       return;
     }
@@ -108,8 +166,9 @@ export const useTextmenuStates = (editor: Editor | null) => {
         });
         return fontSize;
       })(),
+      inheritedFontSize: resolveSelectionFontSize(editor, documentFontSize, documentLineHeight),
     });
-  }, [editor, selectedNode]);
+  }, [editor, selectedNode, documentFontSize, documentLineHeight]);
 
   useEffect(() => {
     if (!editor) return;

--- a/packages/react-designer/src/lib/constants/email-editor-tiptap-styles.test.ts
+++ b/packages/react-designer/src/lib/constants/email-editor-tiptap-styles.test.ts
@@ -4,7 +4,9 @@ import {
   getTierFontSizePx,
   getTierLineHeightPx,
   getTierStyleVars,
+  resolveInheritedTypography,
   resolveLineHeightPx,
+  tierForTextBlock,
 } from "./email-editor-tiptap-styles";
 
 describe("getTierFontSizePx / getTierLineHeightPx", () => {
@@ -129,5 +131,71 @@ describe("getEmailEditorDocumentStyleVars", () => {
 
   it("emits nothing when neither is set", () => {
     expect(getEmailEditorDocumentStyleVars({})).toEqual({});
+  });
+});
+
+describe("tierForTextBlock", () => {
+  it("maps paragraphs to the body tier and headings to their level", () => {
+    expect(tierForTextBlock("paragraph")).toBe("text");
+    expect(tierForTextBlock("heading", 1)).toBe("h1");
+    expect(tierForTextBlock("heading", 2)).toBe("h2");
+    expect(tierForTextBlock("heading", 3)).toBe("h3");
+  });
+
+  it("collapses headings below h3, which Elemental has no tier for", () => {
+    expect(tierForTextBlock("heading", 4)).toBe("h3");
+    expect(tierForTextBlock("heading", 6)).toBe("h3");
+    expect(tierForTextBlock("heading")).toBe("h3");
+  });
+});
+
+// This is what the block-level and text-level inputs show while the block sets
+// nothing of its own, so it has to agree with getEmailEditorDocumentStyleVars —
+// otherwise the field claims a size the canvas doesn't apply.
+describe("resolveInheritedTypography", () => {
+  it("falls back to the tier presets with no document base", () => {
+    expect(resolveInheritedTypography({ tier: "text" })).toEqual({ fontSize: 14, lineHeight: 18 });
+    expect(resolveInheritedTypography({ tier: "h1" })).toEqual({ fontSize: 32, lineHeight: 40 });
+    expect(resolveInheritedTypography({ tier: "quote", isQuote: true })).toEqual({
+      fontSize: 14,
+      lineHeight: 18,
+    });
+  });
+
+  it("takes the document base on the body tier", () => {
+    expect(
+      resolveInheritedTypography({ tier: "text", documentFontSize: 13, documentLineHeight: 15 })
+    ).toEqual({ fontSize: 13, lineHeight: 15 });
+  });
+
+  it("auto-scales the line height off a base font size with no base line height", () => {
+    // Mirrors the renderer: 13 * 1.3, rounded.
+    expect(resolveInheritedTypography({ tier: "text", documentFontSize: 13 })).toEqual({
+      fontSize: 13,
+      lineHeight: 17,
+    });
+  });
+
+  it("keeps the heading preset size but takes an explicit base line height", () => {
+    expect(
+      resolveInheritedTypography({ tier: "h1", documentFontSize: 13, documentLineHeight: 15 })
+    ).toEqual({ fontSize: 32, lineHeight: 15 });
+  });
+
+  it("never lets a base font size derive a line height for a heading", () => {
+    expect(resolveInheritedTypography({ tier: "h2", documentFontSize: 13 })).toEqual({
+      fontSize: 24,
+      lineHeight: 32,
+    });
+  });
+
+  it("resolves quote tiers off the quote presets", () => {
+    expect(resolveInheritedTypography({ tier: "h1", isQuote: true })).toEqual({
+      fontSize: 32,
+      lineHeight: 40,
+    });
+    expect(
+      resolveInheritedTypography({ tier: "text", isQuote: true, documentFontSize: 13 })
+    ).toEqual({ fontSize: 13, lineHeight: 17 });
   });
 });

--- a/packages/react-designer/src/lib/constants/email-editor-tiptap-styles.ts
+++ b/packages/react-designer/src/lib/constants/email-editor-tiptap-styles.ts
@@ -158,6 +158,61 @@ export const resolveLineHeightPx = (
   return undefined;
 };
 
+/**
+ * The tier a paragraph/heading block renders in.
+ *
+ * Anything below h3 collapses to h3, the same way the text block's node view
+ * maps its tag: Elemental has no deeper heading tier.
+ */
+export const tierForTextBlock = (typeName: string, level?: number | null): TextTier => {
+  if (typeName !== "heading") return "text";
+  if (level === 1) return "h1";
+  if (level === 2) return "h2";
+  return "h3";
+};
+
+/**
+ * What a block (or an inline run) would render at if it set nothing itself —
+ * i.e. the next step down the cascade: document base, then the tier preset.
+ *
+ * This is the value the block-level and text-level inputs show as an editable
+ * placeholder. It has to be *derived* rather than stored, because it tracks the
+ * document base: raising the base font size moves every unset block with it.
+ *
+ * Mirrors {@link getEmailEditorDocumentStyleVars} exactly, so what the inputs
+ * claim is what the canvas (and the renderer) actually applies:
+ * - the base font size reaches the body tiers only; headings and subtext keep
+ *   their presets;
+ * - the base line height reaches every tier, and on the body tiers a base font
+ *   size with no base line height auto-scales the same way the renderer does.
+ */
+export function resolveInheritedTypography({
+  tier,
+  isQuote = false,
+  documentFontSize,
+  documentLineHeight,
+}: {
+  tier: TextTier;
+  isQuote?: boolean;
+  documentFontSize?: number | null;
+  documentLineHeight?: number | null;
+}): { fontSize: number; lineHeight: number } {
+  const presetFontSize = getTierFontSizePx(tier, isQuote);
+  const presetLineHeight = getTierLineHeightPx(tier, isQuote);
+
+  if (isPresetSizedTier(tier)) {
+    return {
+      fontSize: presetFontSize,
+      lineHeight: documentLineHeight ?? presetLineHeight,
+    };
+  }
+
+  return {
+    fontSize: documentFontSize ?? presetFontSize,
+    lineHeight: resolveLineHeightPx(documentFontSize, documentLineHeight) ?? presetLineHeight,
+  };
+}
+
 export type StyleVarTier = "p" | "h1" | "h2" | "h3";
 
 /**

--- a/packages/react-designer/src/lib/constants/typography-limits.ts
+++ b/packages/react-designer/src/lib/constants/typography-limits.ts
@@ -1,0 +1,15 @@
+/**
+ * Upper bounds for the authored text metrics, in px, shared by every surface
+ * that edits them: the document-level base (Text section), the per-block
+ * overrides (TypographyFields) and the per-run size (text bubble menu).
+ *
+ * Enforced in the commit paths, not just as the inputs' `max` attribute — a
+ * `type="number"` input still accepts an out-of-range value when it is typed or
+ * pasted, and `max` only blocks the spinner and form validation.
+ */
+export const MAX_FONT_SIZE = 128;
+export const MAX_LINE_HEIGHT = 160;
+
+/** Caps an authored px value, leaving `null` ("inherit") alone. */
+export const clampTypographyValue = (value: number | null, max: number): number | null =>
+  value === null ? null : Math.min(value, max);


### PR DESCRIPTION
Round 1 of the document-level settings feedbacks on [C-19851](https://linear.app/trycourier/issue/C-19851/document-level-settings-feedbacks-round-1) (parent: C-19484).

## 1. Default link blue → `#007AFF`

`a.link` in `typography.css` falls back to `#007AFF` instead of `#1d4ed8` when a host doesn't set `--brand-link-color`. Studio sets that variable from the brand's link colour, so this is the no-brand-colour default.

> **Note:** the backend still renders `#2a9edb` for a brand with no `settings.email.linkColor`. The previews lead deliberately; moving the backend default is a separate change. Agreed with the requester.

## 2. Block-level and selected-text typography no longer render blank

The feedback: *"Having blank values for selected-text font-size or block-level text font-size and line spacing is weird. Those should have their values set to the same value set on the document-level BUT those values should not be saved unless changed."*

The font size / line spacing on text, quote and list blocks, the button's label size, and the bubble menu's text size now show the value the block or run **already renders at** — the document base, then the tier preset — and keep tracking the document base as it moves. Nothing is written to the block until the author types a *different* number, so an untouched block still carries no `font_size` / `line_height` of its own.

```
doc-level:            fs 13 / ls 15
all other levels:     fs 13 / ls 15   (shown, not stored)
author sets doc 12/13
all other levels:     fs 12 / ls 13   (shown, still not stored)
author sets one block 20/24
that block:           fs 20 / ls 24   (stored)
every other block:    fs 12 / ls 13   (still not stored)
```

New `resolveInheritedTypography()` mirrors `getEmailEditorDocumentStyleVars`, so a field cannot claim a size the canvas doesn't apply: the base font size reaches the body tiers only (headings and subtext keep their presets), the base line height reaches every tier, and a base font size with no base line height auto-scales the way the renderer does. For a text run the **closest ancestor block** that sets a size wins — the same order the node views build the tier CSS variables in.

Two consequences worth a look in review:

1. **Typing the number a field already showed writes `null`, not that number.** Persisting it would pin the block so it stopped tracking the document base — the opposite of the ask. So "clear the field" and "retype the base value" both mean *inherit*. Trade-off: you can't deliberately pin a block to the same value as the base.
2. **The bubble menu's size button now always shows a number** (the inherited one when the run inherits), where before it showed nothing.

## 3. Caps — 128px font size, 160px line spacing

`lib/constants/typography-limits.ts`, enforced in **every** commit path — document, block and per-run — not just as the inputs' `max`, which a typed or pasted value bypasses. Over-limit values are capped, not dropped.

## Testing

- **2920 tests pass, 0 fail.** 41 new: the resolver and `tierForTextBlock`, `TypographyFields` placeholder semantics, `FontSizeButton`, and the ancestor walk (`resolveSelectionFontSize`).
- Lint clean on every changed file; `pnpm --filter @trycourier/react-designer build` succeeds.
- Type-check: 187 errors, all pre-existing in test files, down from a 191 baseline — none added.

Vendored into studio as `0.8.0-vendor.f74eabe7f73a` — see the paired frontend PR.