### PR TITLE
fix(react-designer): never let an empty variable serialize to {{}}

### DIFF
--- a/.changeset/empty-variable-mustache.md
+++ b/.changeset/empty-variable-mustache.md
@@ -1,0 +1,11 @@
+---
+"@trycourier/react-designer": patch
+---
+
+Fix empty/unbound variables serializing to `{{}}` (or `{{undefined}}`), which crashed inbox
+sends. An empty mustache is a Handlebars syntax error — the backend render throws and drops
+the whole message (`UNDELIVERABLE`). Every variable-serialization boundary now drops an
+empty-id variable instead of emitting braces: `convertTiptapToElemental`,
+`convertTiptapToMarkdown`, and both variable node schemas (`renderHTML`/`renderText`).
+Existing templates carrying `{{}}` heal on their next save. The editor's "don't flag an
+empty variable while it's being edited" behavior is unchanged.

--- a/packages/react-designer/src/components/extensions/Variable/Variable.ts
+++ b/packages/react-designer/src/components/extensions/Variable/Variable.ts
@@ -61,13 +61,13 @@ export const VariableNode = Node.create<VariableNodeOptions>({
         "data-variable": true,
         ...HTMLAttributes,
       },
-      `{{${node.attrs.id}}}`,
+      // Never emit `{{}}` for an empty/unbound id — it breaks the backend Handlebars compile.
+      node.attrs.id ? `{{${node.attrs.id}}}` : "",
     ];
   },
 
   renderText({ node }) {
-    const result = `{{${node.attrs.id}}}`;
-    return result;
+    return node.attrs.id ? `{{${node.attrs.id}}}` : "";
   },
 
   addNodeView() {

--- a/packages/react-designer/src/components/ui/VariableEditor/shared.tsx
+++ b/packages/react-designer/src/components/ui/VariableEditor/shared.tsx
@@ -128,12 +128,13 @@ export const SimpleVariableNode = Node.create({
         "data-variable": true,
         ...HTMLAttributes,
       },
-      `{{${node.attrs.id}}}`,
+      // Never emit `{{}}` for an empty/unbound id — it breaks the backend Handlebars compile.
+      node.attrs.id ? `{{${node.attrs.id}}}` : "",
     ];
   },
 
   renderText({ node }) {
-    return `{{${node.attrs.id}}}`;
+    return node.attrs.id ? `{{${node.attrs.id}}}` : "";
   },
 
   addNodeView() {

--- a/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts
+++ b/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts
@@ -77,7 +77,9 @@ const markToMD = (mark: TiptapMark): string => {
 
 const convertTextToMarkdown = (node: TiptapNode): string => {
   if (node.type === "variable") {
-    return `{{${node.attrs?.id}}}`;
+    // An empty/unbound variable id serializes to `{{}}`, which the backend Handlebars
+    // compile rejects (parse error) and drops the whole message. Emit nothing instead.
+    return node.attrs?.id ? `{{${node.attrs.id}}}` : "";
   }
 
   let text = node.text || "";
@@ -191,11 +193,14 @@ const convertTiptapNodesToElements = (nodes: TiptapNode[]): ElementalTextContent
     }
 
     if (node.type === "variable") {
+      // Drop an empty/unbound variable rather than emit `{{}}` (a Handlebars parse error
+      // that drops the message). Skip without flushing so surrounding text joins cleanly.
+      if (!node.attrs?.id) continue;
       flush();
       const flags = getFormattingFlags(node.marks);
       elements.push({
         type: "string",
-        content: `{{${node.attrs?.id}}}`,
+        content: `{{${node.attrs.id}}}`,
         ...flags,
       });
       continue;

--- a/packages/react-designer/src/lib/utils/convertTiptapToElemental/emptyVariableGuard.test.ts
+++ b/packages/react-designer/src/lib/utils/convertTiptapToElemental/emptyVariableGuard.test.ts
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect } from "vitest";
+import { convertElementalToTiptap } from "../convertElementalToTiptap/convertElementalToTiptap";
+import { convertTiptapToElemental } from "./convertTiptapToElemental";
+import { convertTiptapToMarkdown } from "../convertTiptapToMarkdown/convertTiptapToMarkdown";
+
+// Regression: an empty/unbound variable must never reach stored content as `{{}}`.
+// The backend Handlebars compile throws a parse error on `{{}}` and drops the whole
+// message (UNDELIVERABLE). Prod repro: template nt_..., v002 title "Something {{}}".
+// The fix guards every serialization boundary so an empty-id variable is dropped, rather
+// than changing the (intentional) "don't flag empty while editing" load behavior.
+
+const docWithEmptyVar = () =>
+  ({
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "Something " },
+          { type: "variable", attrs: { id: "" } },
+        ],
+      },
+    ],
+  }) as any;
+
+const inboxWithText = (text: string) =>
+  ({
+    version: "2022-01-01",
+    elements: [
+      {
+        type: "channel",
+        channel: "inbox",
+        elements: [
+          { type: "meta", title: "t" },
+          { type: "text", content: text },
+        ],
+      },
+    ],
+  }) as any;
+
+const allText = (nodes: any): string => {
+  let s = "";
+  const walk = (n: any) => {
+    if (!n || typeof n !== "object") return;
+    if (typeof n.content === "string") s += n.content + "\n";
+    (Array.isArray(n) ? n : Object.values(n)).forEach((v: any) => typeof v === "object" && walk(v));
+  };
+  walk(nodes);
+  return s;
+};
+
+describe("empty variable ({{}}) serialization guard", () => {
+  it("convertTiptapToElemental drops an empty-id variable (never emits {{}})", () => {
+    expect(allText(convertTiptapToElemental(docWithEmptyVar()))).not.toContain("{{}}");
+  });
+
+  it("convertTiptapToMarkdown drops an empty-id variable (never emits {{}})", () => {
+    expect(convertTiptapToMarkdown(docWithEmptyVar())).not.toContain("{{}}");
+  });
+
+  it("round-trip: loading then saving a poisoned {{}} heals it (no {{}} in output)", () => {
+    const tt = convertElementalToTiptap(inboxWithText("Something {{}}"), {
+      channel: "inbox",
+    } as any);
+    expect(allText(convertTiptapToElemental(tt as any))).not.toContain("{{}}");
+  });
+
+  it("control: a real variable {{data.title}} survives the round-trip", () => {
+    const tt = convertElementalToTiptap(inboxWithText("Hello {{data.title}}"), {
+      channel: "inbox",
+    } as any);
+    expect(allText(convertTiptapToElemental(tt as any))).toContain("{{data.title}}");
+  });
+});

--- a/packages/react-designer/src/lib/utils/convertTiptapToMarkdown/convertTiptapToMarkdown.test.tsx
+++ b/packages/react-designer/src/lib/utils/convertTiptapToMarkdown/convertTiptapToMarkdown.test.tsx
@@ -268,7 +268,7 @@ describe("convertTiptapToMarkdown", () => {
     expect(result).toBe("Hello {{name}}, welcome!");
   });
 
-  it("should convert variable nodes without id attribute", () => {
+  it("should drop variable nodes without an id (never emit {{}}/{{undefined}})", () => {
     const doc = createTiptapDoc([
       {
         type: "paragraph",
@@ -291,7 +291,7 @@ describe("convertTiptapToMarkdown", () => {
 
     const result = convertTiptapToMarkdown(doc);
 
-    expect(result).toBe("Hello {{undefined}}!");
+    expect(result).toBe("Hello !");
   });
 
   it("should convert hard breaks", () => {

--- a/packages/react-designer/src/lib/utils/convertTiptapToMarkdown/convertTiptapToMarkdown.ts
+++ b/packages/react-designer/src/lib/utils/convertTiptapToMarkdown/convertTiptapToMarkdown.ts
@@ -22,7 +22,9 @@ const markToMD = (mark: TiptapMark): string => {
 const convertNodeToMarkdown = (node: TiptapNode): string => {
   switch (node.type) {
     case "variable": {
-      return `{{${node.attrs?.id}}}`;
+      // An empty/unbound variable id serializes to `{{}}`, which the backend Handlebars
+      // compile rejects (parse error) and drops the message. Emit nothing instead.
+      return node.attrs?.id ? `{{${node.attrs.id}}}` : "";
     }
 
     case "text": {


### PR DESCRIPTION
## Problem

An empty/unbound variable serialized to `{{}}` (or `{{undefined}}` when the id was absent). An empty mustache is a **Handlebars syntax error**, so the backend render throws and **drops the whole message**.

**Prod evidence** (inbox template `nt_01kzs2tw…`):
| version | `meta.title` |
|---|---|
| v001 | `"Something"` |
| **v002** (published → dropped) | **`"Something {{}}"`** |
| v003 (healed after an edit) | `"Something {{data.title}}"` |

**Reproduced on dev** — identical backend error and permanent failure:
```
Parse error on line 1:\nSomething {{}}\n------------^\nExpecting 'ID','STRING',… got 'CLOSE'
→ status UNDELIVERABLE / UNROUTABLE (message dropped, willRetry:false)
```

## Root cause

The load path (`convertElementalToTiptap`) accepts an empty mustache as a **valid** empty-id variable (`variableName === "" || …`, regex `[^}]*`), and **five serializers emitted `{{id}}` unguarded** — so an empty-id variable round-trips silently and detonates on send.

## Fix

Guard **every** variable-serialization boundary so an empty-id variable is **dropped**, never emitted as braces:
- `convertTiptapToElemental` (both serializers)
- `convertTiptapToMarkdown`
- `Variable.ts` and `shared.tsx` node schemas (`renderHTML`/`renderText`)

Existing poisoned templates **heal on their next save**. The intentional load-path behavior (don't flag an empty variable *while it's being edited*) is left unchanged — fixing at the write boundary is the surgical choice.

## Tests
- New round-trip regression test (load `{{}}` → save → no `{{}}`; control `{{data.title}}` survives).
- Updated one existing test that had locked in the old buggy `{{undefined}}` output.
- **Full suite: 2929 passing.** Lint clean. Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)