### PR TITLE
fix(designer): show the selected version in read-only channel previews [C-19931]

### DIFF
--- a/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.content-stability.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.content-stability.test.tsx
@@ -235,3 +235,99 @@ describe("Inbox Content Stability (Bug C-16410)", () => {
     expect(contentWasSet).toBe(true);
   });
 });
+
+/**
+ * Tests for read-only version preview (C-19931)
+ *
+ * The counterpart to C-16410 above. Freezing the content memo fixed editing,
+ * but it also froze the read-only canvas: the template editor's version-history
+ * panel swaps the `value` prop to the selected saved version, and Inbox threw it
+ * away, so the preview kept showing whichever version loaded first.
+ */
+describe("Inbox read-only version preview (C-19931)", () => {
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    store = createStore();
+    store.set(isTemplateLoadingAtom, false);
+    store.set(isTemplateTransitioningAtom, false);
+    store.set(pendingAutoSaveAtom, null);
+    store.set(templateEditorContentAtom, createInboxContent("Draft title", "Draft body"));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Renders the doc the canvas would show, so we assert content not identity.
+   * Inbox restructures its elements on the way in — the title is the text that
+   * survives into a visible node — so these tests assert on the title.
+   */
+  const ContentText = ({ content }: InboxRenderProps) => (
+    <div data-testid="content-text">{JSON.stringify(content)}</div>
+  );
+
+  it("shows the newly selected version when `value` changes while read-only", async () => {
+    const { rerender } = render(
+      <Provider store={store}>
+        <Inbox
+          readOnly
+          value={createInboxContent("TITLE ONE", "Body one")}
+          routing={{ method: "single", channels: ["inbox"] }}
+          render={ContentText}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("TITLE ONE");
+    });
+
+    rerender(
+      <Provider store={store}>
+        <Inbox
+          readOnly
+          value={createInboxContent("TITLE TWO", "Body two")}
+          routing={{ method: "single", channels: ["inbox"] }}
+          render={ContentText}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("TITLE TWO");
+    });
+  });
+
+  it("still freezes content when `value` changes while editable (keeps C-16410 fixed)", async () => {
+    const { rerender } = render(
+      <Provider store={store}>
+        <Inbox
+          value={createInboxContent("TITLE ONE", "Body one")}
+          routing={{ method: "single", channels: ["inbox"] }}
+          render={ContentText}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("TITLE ONE");
+    });
+
+    rerender(
+      <Provider store={store}>
+        <Inbox
+          value={createInboxContent("TITLE TWO", "Body two")}
+          routing={{ method: "single", channels: ["inbox"] }}
+          render={ContentText}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("TITLE ONE");
+    });
+    expect(screen.getByTestId("content-text")).not.toHaveTextContent("TITLE TWO");
+  });
+});

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.legacy-title.test.ts
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.legacy-title.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { getOrCreateInboxElement } from "./Inbox";
+import type { ElementalContent, ElementalNode } from "@/types/elemental.types";
+
+/**
+ * Older saved versions do not store the inbox title where the current editor
+ * puts it. `getSubjectStorageFormat` recognises two formats — `channel.raw.title`
+ * and a `meta` element — and versions predating both kept the title as the first
+ * h2 text element. The canvas read path only understood `meta`, so selecting an
+ * older version in version history rendered an empty title, promoted the title
+ * into the body slot, and dropped the real body.
+ */
+const inbox = (channel: Record<string, unknown>): ElementalContent =>
+  ({
+    version: "2022-01-01",
+    elements: [{ type: "channel", channel: "inbox", ...channel }],
+  }) as ElementalContent;
+
+const read = (content: ElementalContent) => {
+  const el = getOrCreateInboxElement(content) as ElementalNode & { elements: ElementalNode[] };
+  const [header, body] = el.elements;
+  const text = (n: ElementalNode) => ("content" in n ? String(n.content).trim() : "");
+  return { title: text(header), body: text(body) };
+};
+
+describe("inbox legacy title formats (C-19931)", () => {
+  it("reads the current meta format", () => {
+    expect(
+      read(
+        inbox({
+          elements: [
+            { type: "meta", title: "The title" },
+            { type: "text", content: "The body" },
+          ],
+        })
+      )
+    ).toEqual({ title: "The title", body: "The body" });
+  });
+
+  it("reads a title stored on channel.raw", () => {
+    expect(
+      read(
+        inbox({
+          raw: { title: "The title" },
+          elements: [{ type: "text", content: "The body" }],
+        })
+      )
+    ).toEqual({ title: "The title", body: "The body" });
+  });
+
+  it("reads a title stored as the leading h2 text element", () => {
+    expect(
+      read(
+        inbox({
+          elements: [
+            { type: "text", content: "The title", text_style: "h2" },
+            { type: "text", content: "The body" },
+          ],
+        })
+      )
+    ).toEqual({ title: "The title", body: "The body" });
+  });
+
+  it("keeps action buttons in every format", () => {
+    const el = getOrCreateInboxElement(
+      inbox({
+        raw: { title: "T" },
+        elements: [
+          { type: "text", content: "B" },
+          { type: "action", content: "Go", href: "", align: "left" },
+        ],
+      })
+    ) as ElementalNode & { elements: ElementalNode[] };
+    expect(el.elements.filter((n) => n.type === "action")).toHaveLength(1);
+  });
+});

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.tsx
@@ -368,7 +368,7 @@ const InboxComponent = forwardRef<HTMLDivElement, InboxProps>(
     // selection reaches the canvas (ReadOnlyEditorContent re-applies whatever
     // this memo returns). Nothing is being typed, so it is safe. While editable
     // the memo stays frozen: see the dependency note below.
-    const readOnlyValue = readOnly ? value : null;
+    const readOnlyValue = readOnly ? (value ?? templateEditorContent) : null;
 
     // Derive content once on mount - EditorProvider uses this as initial value only
     // Subsequent updates flow through restoration effect in InboxEditorContent

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.tsx
@@ -340,6 +340,13 @@ const InboxComponent = forwardRef<HTMLDivElement, InboxProps>(
       [templateEditorContent, setTemplateEditorContent, setPendingAutoSave, isTemplateTransitioning]
     );
 
+    // While read-only — version history, Preview & Test — the host swaps `value`
+    // to show a different saved version, and re-deriving is the only way that
+    // selection reaches the canvas (ReadOnlyEditorContent re-applies whatever
+    // this memo returns). Nothing is being typed, so it is safe. While editable
+    // the memo stays frozen: see the dependency note below.
+    const readOnlyValue = readOnly ? value : null;
+
     // Derive content once on mount - EditorProvider uses this as initial value only
     // Subsequent updates flow through restoration effect in InboxEditorContent
     const content = useMemo(() => {
@@ -365,7 +372,7 @@ const InboxComponent = forwardRef<HTMLDivElement, InboxProps>(
 
       return convertElementalToTiptap(elementalForConversion, { channel: "inbox" });
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isTemplateLoading, previewLocale]); // Only recompute when loading state or locale changes - value/templateEditorContent intentionally omitted to keep EditorProvider stable
+    }, [isTemplateLoading, previewLocale, readOnlyValue]); // `value`/`templateEditorContent` are read but intentionally omitted from the deps while editable: EditorProvider treats `content` as an initial value and live edits flow back out through onUpdate, so re-deriving mid-edit would fight the user's cursor. `readOnlyValue` re-admits `value` only when read-only.
 
     return (
       <MainLayout

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Inbox/Inbox.tsx
@@ -69,8 +69,31 @@ export const getOrCreateInboxElement = (
     const textElements = otherElements.filter((el: ElementalNode) => el.type === "text");
     const actionElements = otherElements.filter((el: ElementalNode) => el.type === "action");
 
-    // Build the fixed structure: 1 header + 1 body + actions
-    const titleContent = metaElement && "title" in metaElement ? metaElement.title || "" : "";
+    // Build the fixed structure: 1 header + 1 body + actions.
+    //
+    // The title has lived in three places across the template history, and
+    // version history can hand us any of them. `getSubjectStorageFormat` knows
+    // the first two; the third predates both. Reading only `meta` rendered older
+    // versions with an empty title — and in the h2 case promoted the title into
+    // the body slot and dropped the real body.
+    const metaTitle = metaElement && "title" in metaElement ? metaElement.title || "" : "";
+    const rawTitle =
+      "raw" in element && element.raw && "title" in element.raw
+        ? (element.raw as { title?: string }).title || ""
+        : "";
+
+    // Legacy: the title kept as the leading h2 text element rather than lifted
+    // out. Only treat it as the title when neither of the newer homes has one,
+    // so current content is unaffected.
+    const leading = textElements[0];
+    const leadingIsHeading = leading && "text_style" in leading && leading.text_style === "h2";
+    const useLeadingAsTitle = !metaTitle && !rawTitle && Boolean(leadingIsHeading);
+
+    const titleContent = useLeadingAsTitle
+      ? leading && "content" in leading
+        ? String(leading.content)
+        : ""
+      : metaTitle || rawTitle;
 
     // Header element (h2)
     const headerElement = {
@@ -79,9 +102,9 @@ export const getOrCreateInboxElement = (
       text_style: "h2" as const,
     };
 
-    // Body element - use first text element or create empty one
-    // Only keep ONE body paragraph
-    const firstBodyText = textElements[0];
+    // Body element - the first text element that was not consumed as the title.
+    // Only keep ONE body paragraph.
+    const firstBodyText = textElements[useLeadingAsTitle ? 1 : 0];
     const bodyElement = {
       type: "text" as const,
       content:

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Push/Push.content-stability.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Push/Push.content-stability.test.tsx
@@ -231,3 +231,95 @@ describe("Push Content Stability (Bug C-16410)", () => {
     expect(contentWasSet).toBe(true);
   });
 });
+
+/**
+ * Tests for read-only version preview (C-19931)
+ *
+ * The counterpart to C-16410 above. Freezing the content memo fixed editing,
+ * but it also froze the read-only canvas: the template editor's version-history
+ * panel swaps the `value` prop to the selected saved version, and Push threw it
+ * away, so the preview kept showing whichever version loaded first.
+ */
+describe("Push read-only version preview (C-19931)", () => {
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    store = createStore();
+    store.set(isTemplateLoadingAtom, false);
+    store.set(isTemplateTransitioningAtom, false);
+    store.set(pendingAutoSaveAtom, null);
+    store.set(templateEditorContentAtom, createPushContent("Draft title", "Draft body"));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /** Renders the doc the canvas would show, so we assert content not identity. */
+  const ContentText = ({ content }: PushRenderProps) => (
+    <div data-testid="content-text">{JSON.stringify(content)}</div>
+  );
+
+  it("shows the newly selected version when `value` changes while read-only", async () => {
+    const { rerender } = render(
+      <Provider store={store}>
+        <Push
+          readOnly
+          value={createPushContent("TITLE ONE", "BODY ONE")}
+          routing={{ method: "single", channels: ["push"] }}
+          render={ContentText}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("BODY ONE");
+    });
+
+    rerender(
+      <Provider store={store}>
+        <Push
+          readOnly
+          value={createPushContent("TITLE TWO", "BODY TWO")}
+          routing={{ method: "single", channels: ["push"] }}
+          render={ContentText}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("BODY TWO");
+    });
+  });
+
+  it("still freezes content when `value` changes while editable (keeps C-16410 fixed)", async () => {
+    const { rerender } = render(
+      <Provider store={store}>
+        <Push
+          value={createPushContent("TITLE ONE", "BODY ONE")}
+          routing={{ method: "single", channels: ["push"] }}
+          render={ContentText}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("BODY ONE");
+    });
+
+    rerender(
+      <Provider store={store}>
+        <Push
+          value={createPushContent("TITLE TWO", "BODY TWO")}
+          routing={{ method: "single", channels: ["push"] }}
+          render={ContentText}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("BODY ONE");
+    });
+    expect(screen.getByTestId("content-text")).not.toHaveTextContent("BODY TWO");
+  });
+});

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Push/Push.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Push/Push.tsx
@@ -341,6 +341,13 @@ const PushComponent = forwardRef<HTMLDivElement, PushProps>(
       [templateEditorContent, setTemplateEditorContent, setPendingAutoSave, isTemplateTransitioning]
     );
 
+    // While read-only — version history, Preview & Test — the host swaps `value`
+    // to show a different saved version, and re-deriving is the only way that
+    // selection reaches the canvas (ReadOnlyEditorContent re-applies whatever
+    // this memo returns). Nothing is being typed, so it is safe. While editable
+    // the memo stays frozen: see the dependency note below.
+    const readOnlyValue = readOnly ? value : null;
+
     // Derive content once on mount - EditorProvider uses this as initial value only
     // Subsequent updates flow through restoration effect in PushEditorContent
     const content = useMemo(() => {
@@ -398,7 +405,7 @@ const PushComponent = forwardRef<HTMLDivElement, PushProps>(
 
       return convertElementalToTiptap(elementalForConversion);
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isTemplateLoading, previewLocale]); // Only recompute when loading state or locale changes - value/templateEditorContent intentionally omitted to keep EditorProvider stable
+    }, [isTemplateLoading, previewLocale, readOnlyValue]); // `value`/`templateEditorContent` are read but intentionally omitted from the deps while editable: EditorProvider treats `content` as an initial value and live edits flow back out through onUpdate, so re-deriving mid-edit would fight the user's cursor. `readOnlyValue` re-admits `value` only when read-only.
 
     return (
       <MainLayout

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Push/Push.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Push/Push.tsx
@@ -346,7 +346,7 @@ const PushComponent = forwardRef<HTMLDivElement, PushProps>(
     // selection reaches the canvas (ReadOnlyEditorContent re-applies whatever
     // this memo returns). Nothing is being typed, so it is safe. While editable
     // the memo stays frozen: see the dependency note below.
-    const readOnlyValue = readOnly ? value : null;
+    const readOnlyValue = readOnly ? (value ?? templateEditorContent) : null;
 
     // Derive content once on mount - EditorProvider uses this as initial value only
     // Subsequent updates flow through restoration effect in PushEditorContent

--- a/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.content-stability.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.content-stability.test.tsx
@@ -400,4 +400,26 @@ describe("SMS read-only version preview (C-19931)", () => {
     });
     expect(screen.getByTestId("content-text")).not.toHaveTextContent("VERSION TWO");
   });
+  it("re-derives from templateEditorContent when read-only and no `value` is passed", async () => {
+    // Guards the wiring, not just the memo: a host that drives the canvas
+    // through the atom rather than the `value` prop must still see the
+    // selected version. Keying only off `value` made this silently inert.
+    const { rerender } = render(
+      <Provider store={store}>
+        <SMS readOnly routing={{ method: "single", channels: ["sms"] }} render={ContentText} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("Draft content");
+    });
+
+    await act(async () => {
+      store.set(templateEditorContentAtom, createSMSContent("VERSION TWO"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("VERSION TWO");
+    });
+  });
 });

--- a/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.content-stability.test.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.content-stability.test.tsx
@@ -304,3 +304,100 @@ describe("SMS Content Stability (Bug C-16410)", () => {
     expect(contentWasSet).toBe(true);
   });
 });
+
+/**
+ * Tests for read-only version preview (C-19931)
+ *
+ * The counterpart to C-16410 above. Freezing the content memo fixed editing,
+ * but it also froze the read-only canvas: the template editor's version-history
+ * panel swaps the `value` prop to the selected saved version, and SMS threw it
+ * away, so the preview kept showing whichever version loaded first.
+ *
+ * While read-only nothing is being typed, so re-deriving is safe — and it is the
+ * only path by which the selection reaches the canvas.
+ */
+describe("SMS read-only version preview (C-19931)", () => {
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    store = createStore();
+    store.set(isTemplateLoadingAtom, false);
+    store.set(isTemplateTransitioningAtom, false);
+    store.set(pendingAutoSaveAtom, null);
+    store.set(templateEditorContentAtom, createSMSContent("Draft content"));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /** Renders the SMS text the canvas would show, so we assert content not identity. */
+  const ContentText = ({ content }: SMSRenderProps) => (
+    <div data-testid="content-text">{JSON.stringify(content)}</div>
+  );
+
+  it("shows the newly selected version when `value` changes while read-only", async () => {
+    const { rerender } = render(
+      <Provider store={store}>
+        <SMS
+          readOnly
+          value={createSMSContent("VERSION ONE")}
+          routing={{ method: "single", channels: ["sms"] }}
+          render={ContentText}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("VERSION ONE");
+    });
+
+    // The user clicks a different version in the history panel.
+    rerender(
+      <Provider store={store}>
+        <SMS
+          readOnly
+          value={createSMSContent("VERSION TWO")}
+          routing={{ method: "single", channels: ["sms"] }}
+          render={ContentText}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("VERSION TWO");
+    });
+  });
+
+  it("still freezes content when `value` changes while editable (keeps C-16410 fixed)", async () => {
+    const { rerender } = render(
+      <Provider store={store}>
+        <SMS
+          value={createSMSContent("VERSION ONE")}
+          routing={{ method: "single", channels: ["sms"] }}
+          render={ContentText}
+        />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("VERSION ONE");
+    });
+
+    rerender(
+      <Provider store={store}>
+        <SMS
+          value={createSMSContent("VERSION TWO")}
+          routing={{ method: "single", channels: ["sms"] }}
+          render={ContentText}
+        />
+      </Provider>
+    );
+
+    // Editing must not be interrupted by a re-derive.
+    await waitFor(() => {
+      expect(screen.getByTestId("content-text")).toHaveTextContent("VERSION ONE");
+    });
+    expect(screen.getByTestId("content-text")).not.toHaveTextContent("VERSION TWO");
+  });
+});

--- a/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.tsx
@@ -291,6 +291,13 @@ const SMSComponent = forwardRef<HTMLDivElement, SMSProps>(
       [templateEditorContent, setTemplateEditorContent, setPendingAutoSave, isTemplateTransitioning]
     );
 
+    // While read-only — version history, Preview & Test — the host swaps `value`
+    // to show a different saved version, and re-deriving is the only way that
+    // selection reaches the canvas (ReadOnlyEditorContent re-applies whatever
+    // this memo returns). Nothing is being typed, so it is safe. While editable
+    // the memo stays frozen: see the dependency note below.
+    const readOnlyValue = readOnly ? value : null;
+
     // Derive content once on mount - EditorProvider uses this as initial value only
     // Subsequent updates flow through restoration effect in SMSEditorContent
     const content = useMemo(() => {
@@ -338,7 +345,7 @@ const SMSComponent = forwardRef<HTMLDivElement, SMSProps>(
 
       return convertElementalToTiptap(elementalForConversion);
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isTemplateLoading, previewLocale]); // Only recompute when loading state or locale changes - value/templateEditorContent intentionally omitted to keep EditorProvider stable
+    }, [isTemplateLoading, previewLocale, readOnlyValue]); // `value`/`templateEditorContent` are read but intentionally omitted from the deps while editable: EditorProvider treats `content` as an initial value and live edits flow back out through onUpdate, so re-deriving mid-edit would fight the user's cursor. `readOnlyValue` re-admits `value` only when read-only.
 
     return (
       <MainLayout

--- a/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/SMS/SMS.tsx
@@ -296,7 +296,7 @@ const SMSComponent = forwardRef<HTMLDivElement, SMSProps>(
     // selection reaches the canvas (ReadOnlyEditorContent re-applies whatever
     // this memo returns). Nothing is being typed, so it is safe. While editable
     // the memo stays frozen: see the dependency note below.
-    const readOnlyValue = readOnly ? value : null;
+    const readOnlyValue = readOnly ? (value ?? templateEditorContent) : null;
 
     // Derive content once on mount - EditorProvider uses this as initial value only
     // Subsequent updates flow through restoration effect in SMSEditorContent

--- a/packages/react-designer/src/components/TemplateEditor/Channels/architecture-consistency.test.ts
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/architecture-consistency.test.ts
@@ -64,8 +64,11 @@ describe("Architecture Consistency Tests", () => {
 
           if (useMemoMatch) {
             const deps = useMemoMatch[1].trim();
-            // Should depend on isTemplateLoading and optionally previewLocale
-            expect(deps).toMatch(/^isTemplateLoading(, previewLocale)?$/);
+            // Should depend on isTemplateLoading and optionally previewLocale.
+            // `readOnlyValue` (C-19931) is also allowed: it is `value` while the
+            // editor is read-only and `null` while editable, so the memo still
+            // never re-derives underneath an active edit.
+            expect(deps).toMatch(/^isTemplateLoading(, previewLocale)?(, readOnlyValue)?$/);
           }
         });
 
@@ -89,9 +92,15 @@ describe("Architecture Consistency Tests", () => {
           );
 
           if (useMemoMatch) {
-            const deps = useMemoMatch[1];
-            // Should NOT include value (causes unnecessary re-renders)
-            expect(deps).not.toContain("value");
+            const depNames = useMemoMatch[1]
+              .split(",")
+              .map((dep) => dep.trim())
+              .filter(Boolean);
+            // Should NOT include a bare `value` (causes unnecessary re-renders).
+            // `readOnlyValue` is a distinct dependency and is allowed — see the
+            // primary-dependency test above for why. Compare whole dependency
+            // names rather than substrings so the two cannot be confused.
+            expect(depNames).not.toContain("value");
           }
         });
 
@@ -191,7 +200,7 @@ describe("Architecture Consistency Tests", () => {
       // All channels should have the same dependency pattern
       expect(patterns.length).toBe(3);
       expect(new Set(patterns).size).toBe(1); // All should be identical
-      expect(patterns[0]).toMatch(/^isTemplateLoading(, previewLocale)?$/);
+      expect(patterns[0]).toMatch(/^isTemplateLoading(, previewLocale)?(, readOnlyValue)?$/);
     });
 
     it("all fixed channels should NOT have the old buggy pattern", () => {


### PR DESCRIPTION
Studio's template editor has a version-history panel. Selecting a version there sets the designer's content — but three channels threw it away, so the canvas kept rendering whichever version happened to load first.

Companion studio PR: trycourier/frontend#5383.

---

## 1. Re-derive while read-only

`SMS`, `Push` and `Inbox` derive their tiptap doc in a `useMemo` keyed only on `[isTemplateLoading, previewLocale]`. That freeze is deliberate — it is the C-16410 fix: `EditorProvider` treats `content` as an initial value and live edits flow back out through `onUpdate`, so re-deriving mid-edit fights the user's cursor. `Email`, `Slack` and `MSTeams` already depend on `value` and were unaffected.

The memos now also depend on `readOnlyValue` — `value ?? templateEditorContent` while `readOnly`, `null` while editable. Version history and Preview & Test are read-only, so nothing is being typed and re-deriving is safe; editing keeps the frozen behaviour C-16410 needs.

The first cut keyed only off the `value` prop, which left it **inert** for a host that drives the canvas through `templateEditorContentAtom`. Hence the atom fallback, plus a test that renders read-only with no `value` at all.

## 2. Read legacy inbox title formats

Selecting an older version rendered the inbox channel wrong: empty title, the title promoted into the body slot, and the real body dropped.

The inbox title has lived in three places. `getSubjectStorageFormat` already recognises two — `channel.raw.title` and a `meta` element — and versions predating both kept it as the leading h2 text element. The write path (`createTitleUpdate`) normalises to `meta` + exactly one body text, so current content round-trips; but `getOrCreateInboxElement`, which feeds the canvas, read `meta.title` and nothing else, then took the body from `textElements[0]`. For anything stored the older ways, that slot holds the title.

It now falls back meta → raw → leading h2, and takes the body from the first text element not consumed as the title. The fallbacks engage only when the newer homes are empty, so current content is untouched.

## Testing

**2940 tests pass** (121 files) · `lint:src` gate clean.

- Each channel's stability suite gains both halves of the contract: the selection reaches the canvas while read-only, **and** content still freezes while editable.
- New `Inbox.legacy-title.test.ts` covers all three storage shapes plus action-button preservation.
- Verified by reverting each fix and confirming only the intended test fails, then restoring — for all three channels and for the legacy-title read.
- `architecture-consistency` guards updated to admit `readOnlyValue`. Its bare-`value` check now compares whole dependency names instead of substrings, which it previously passed only by case-sensitivity accident.

## Note for reviewers

`readOnly` is a real signal here, not a proxy for something else — but studio was not passing it to the channel root at all, only to `ChannelRootContainer` and the inner editor. That is why the first version of this change did nothing; #5383 wires it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
