### PR TITLE
fix(email): stop emitting quote frame fields no renderer reads [C-19960]

### DIFF
--- a/.changeset/quiet-quote-frames.md
+++ b/.changeset/quiet-quote-frames.md
@@ -1,0 +1,11 @@
+---
+"@trycourier/react-designer": patch
+---
+
+Stop serializing the quote frame fields `border_left_width`, `padding_horizontal` and
+`padding_vertical`. No render path reads them — the email renderer reads `border_size` and
+`padding` — and the designer exposes no control for any of them, so they were written on
+every quote purely from the Blockquote attr defaults. `convertElementalToTiptap` still reads
+them (numbers or strings) so quotes stored before this change keep their frame in the editor,
+and they are dropped on the next save. `elemental.types.ts` / `elemental.schema.ts` keep the
+fields marked deprecated and read-only.

--- a/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.test.tsx
+++ b/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.test.tsx
@@ -4047,4 +4047,74 @@ describe("convertElementalToTiptap", () => {
       expect((result[0] as any).if).toBeUndefined();
     });
   });
+
+  describe("quote frame fields (C-19960)", () => {
+    // border_left_width / padding_horizontal / padding_vertical are designer-only
+    // fields the serializer no longer emits. They are still read here so quotes
+    // stored before that change keep their frame in the editor.
+    const quoteWith = (fields: Record<string, unknown>) =>
+      createElementalContent([{ type: "quote", content: "Framed quote", ...fields } as any]);
+
+    const frameAttrs = (elemental: ElementalContent) => {
+      const result = convertElementalToTiptap(elemental);
+      return (result.content[0] as any).attrs;
+    };
+
+    it("reads the deprecated frame fields into Blockquote attrs", () => {
+      expect(
+        frameAttrs(
+          quoteWith({ border_left_width: 4, padding_horizontal: 8, padding_vertical: 6 })
+        )
+      ).toMatchObject({
+        borderLeftWidth: 4,
+        paddingHorizontal: 8,
+        paddingVertical: 6,
+      });
+    });
+
+    it("reads them when stored as strings", () => {
+      // A sample of stored quotes carries these as strings rather than numbers.
+      expect(
+        frameAttrs(
+          quoteWith({ border_left_width: "2", padding_horizontal: "20", padding_vertical: "4" })
+        )
+      ).toMatchObject({
+        borderLeftWidth: 2,
+        paddingHorizontal: 20,
+        paddingVertical: 4,
+      });
+    });
+
+    it("reads a zero border width rather than treating it as absent", () => {
+      expect(frameAttrs(quoteWith({ border_left_width: 0 }))).toMatchObject({
+        borderLeftWidth: 0,
+      });
+    });
+
+    it("omits the attrs entirely when the fields are absent, so node defaults apply", () => {
+      const attrs = frameAttrs(quoteWith({}));
+
+      expect(attrs).not.toHaveProperty("borderLeftWidth");
+      expect(attrs).not.toHaveProperty("paddingHorizontal");
+      expect(attrs).not.toHaveProperty("paddingVertical");
+    });
+
+    it("ignores unparseable values", () => {
+      const attrs = frameAttrs(quoteWith({ border_left_width: "thick", padding_vertical: null }));
+
+      expect(attrs).not.toHaveProperty("borderLeftWidth");
+      expect(attrs).not.toHaveProperty("paddingVertical");
+    });
+
+    it("drops the fields on the next save", () => {
+      const tiptap = convertElementalToTiptap(
+        quoteWith({ border_left_width: 4, padding_horizontal: 8, padding_vertical: 6 })
+      );
+      const result = convertTiptapToElemental(tiptap);
+
+      expect(result[0]).not.toHaveProperty("border_left_width");
+      expect(result[0]).not.toHaveProperty("padding_horizontal");
+      expect(result[0]).not.toHaveProperty("padding_vertical");
+    });
+  });
 });

--- a/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
+++ b/packages/react-designer/src/lib/utils/convertElementalToTiptap/convertElementalToTiptap.ts
@@ -65,6 +65,52 @@ const elementalAlignToTiptap = (align: string | undefined): string => {
 };
 
 /**
+ * Coerce a deprecated quote frame value to a number. Stored quotes carry these
+ * as numbers in most cases but as strings in some, so accept both.
+ */
+const parseQuoteFrameValue = (value: number | string | undefined): number | undefined => {
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== "string") return undefined;
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+/**
+ * Read a quote's frame (left border width + padding) into Blockquote attrs.
+ *
+ * `border_left_width`, `padding_horizontal` and `padding_vertical` are
+ * designer-only fields that no render path reads, and that the designer exposes
+ * no control for. The serializer stopped emitting them in C-19960, but stored
+ * content still carries them — so they are read here to keep those quotes
+ * looking the same in the editor, and are dropped on the next save.
+ */
+const readQuoteFrameAttrs = (node: {
+  border_left_width?: number | string;
+  padding_horizontal?: number | string;
+  padding_vertical?: number | string;
+}): { borderLeftWidth?: number; paddingVertical?: number; paddingHorizontal?: number } => {
+  const attrs: { borderLeftWidth?: number; paddingVertical?: number; paddingHorizontal?: number } =
+    {};
+
+  const borderLeftWidth = parseQuoteFrameValue(node.border_left_width);
+  if (borderLeftWidth !== undefined) {
+    attrs.borderLeftWidth = borderLeftWidth;
+  }
+
+  const paddingVertical = parseQuoteFrameValue(node.padding_vertical);
+  if (paddingVertical !== undefined) {
+    attrs.paddingVertical = paddingVertical;
+  }
+
+  const paddingHorizontal = parseQuoteFrameValue(node.padding_horizontal);
+  if (paddingHorizontal !== undefined) {
+    attrs.paddingHorizontal = paddingHorizontal;
+  }
+
+  return attrs;
+};
+
+/**
  * Convert an Elemental elements array (type: "string" | "link" sub-elements with boolean
  * formatting flags) into TipTap nodes. Handles variables ({{var}}) and newlines (\n → hardBreak).
  */
@@ -854,15 +900,7 @@ export function convertElementalToTiptap(
               textAlign: node.align || "left",
               id: `node-${uuidv4()}`,
               ...(node.border_color && { borderColor: node.border_color }),
-              ...(node.border_left_width !== undefined && {
-                borderLeftWidth: node.border_left_width,
-              }),
-              ...(node.padding_horizontal !== undefined && {
-                paddingHorizontal: node.padding_horizontal,
-              }),
-              ...(node.padding_vertical !== undefined && {
-                paddingVertical: node.padding_vertical,
-              }),
+              ...readQuoteFrameAttrs(node),
               ...readTypographyAttrs(
                 node,
                 (node.text_style ?? "quote") as TextTier,

--- a/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.test.tsx
+++ b/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.test.tsx
@@ -3885,4 +3885,72 @@ describe("convertTiptapToElemental", () => {
       expect(textNode.locales.de.elements).toEqual([{ type: "string", content: "Hallo" }]);
     });
   });
+
+  describe("quote frame serialization (C-19960)", () => {
+    // The quote branch used to emit border_left_width / padding_horizontal /
+    // padding_vertical on every quote, straight from the Blockquote attr
+    // defaults. No render path reads them and the designer exposes no control
+    // for them, so they are no longer serialized at all.
+    const quoteWithFrame = (attrs: Record<string, unknown>) =>
+      createTiptapDoc([
+        {
+          type: "blockquote",
+          attrs,
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Framed quote" }],
+            },
+          ],
+        },
+      ]);
+
+    it("does not emit the frame fields for a non-default frame", () => {
+      const result = convertTiptapToElemental(
+        quoteWithFrame({ borderLeftWidth: 4, paddingVertical: 6, paddingHorizontal: 8 })
+      );
+
+      expect(result[0]).toEqual({ type: "quote", content: "Framed quote" });
+    });
+
+    it("does not emit the frame fields for the Blockquote defaults", () => {
+      const result = convertTiptapToElemental(
+        quoteWithFrame({ borderLeftWidth: 2, paddingVertical: 4, paddingHorizontal: 20 })
+      );
+
+      expect(result[0]).not.toHaveProperty("border_left_width");
+      expect(result[0]).not.toHaveProperty("padding_horizontal");
+      expect(result[0]).not.toHaveProperty("padding_vertical");
+    });
+
+    it("does not substitute border_size or padding for them", () => {
+      // The quote frame is not an authorable property, so it is dropped rather
+      // than rewritten into the canonical spelling the renderer would read.
+      const result = convertTiptapToElemental(
+        quoteWithFrame({ borderLeftWidth: 4, paddingVertical: 6, paddingHorizontal: 8 })
+      );
+
+      expect(result[0]).not.toHaveProperty("border_size");
+      expect(result[0]).not.toHaveProperty("padding");
+    });
+
+    it("still emits the properties the quote form does expose", () => {
+      const result = convertTiptapToElemental(
+        quoteWithFrame({
+          borderColor: "#cccccc",
+          backgroundColor: "#f5f5f5",
+          borderLeftWidth: 2,
+          paddingVertical: 4,
+          paddingHorizontal: 20,
+        })
+      );
+
+      expect(result[0]).toEqual({
+        type: "quote",
+        content: "Framed quote",
+        border_color: "#cccccc",
+        background_color: "#f5f5f5",
+      });
+    });
+  });
 });

--- a/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts
+++ b/packages/react-designer/src/lib/utils/convertTiptapToElemental/convertTiptapToElemental.ts
@@ -470,19 +470,6 @@ export function convertTiptapToElemental(tiptap: TiptapDoc): ElementalNode[] {
           quoteNode.border_color = node.attrs.borderColor as string;
         }
 
-        // Preserve frame settings
-        if (node.attrs?.borderLeftWidth !== undefined) {
-          quoteNode.border_left_width = node.attrs.borderLeftWidth as number;
-        }
-
-        if (node.attrs?.paddingHorizontal !== undefined) {
-          quoteNode.padding_horizontal = node.attrs.paddingHorizontal as number;
-        }
-
-        if (node.attrs?.paddingVertical !== undefined) {
-          quoteNode.padding_vertical = node.attrs.paddingVertical as number;
-        }
-
         if (node.attrs?.backgroundColor && node.attrs.backgroundColor !== "transparent") {
           quoteNode.background_color = node.attrs.backgroundColor as string;
         }

--- a/packages/react-designer/src/types/elemental.schema.ts
+++ b/packages/react-designer/src/types/elemental.schema.ts
@@ -232,9 +232,6 @@ const QuoteNode: z.ZodType<ElementalQuoteNode> = BaseElementalNode.extend({
   content: z.string(),
   align: AlignEnum.optional(),
   border_color: z.string().optional(),
-  border_left_width: z.number().optional(),
-  padding_horizontal: z.number().optional(),
-  padding_vertical: z.number().optional(),
   background_color: z.string().optional(),
   font_size: z.string().optional(),
   line_height: z.string().optional(),
@@ -246,6 +243,12 @@ const QuoteNode: z.ZodType<ElementalQuoteNode> = BaseElementalNode.extend({
       })
     )
     .optional(),
+  // Deprecated designer-only fields no render path reads. Still accepted so
+  // content stored before C-19960 validates; read on load, never emitted.
+  // Stored values are sometimes strings rather than numbers.
+  border_left_width: z.union([z.number(), z.string()]).optional(),
+  padding_horizontal: z.union([z.number(), z.string()]).optional(),
+  padding_vertical: z.union([z.number(), z.string()]).optional(),
 });
 
 const HtmlNode: z.ZodType<ElementalHtmlNode> = BaseElementalNode.extend({

--- a/packages/react-designer/src/types/elemental.types.ts
+++ b/packages/react-designer/src/types/elemental.types.ts
@@ -339,9 +339,6 @@ export interface ElementalQuoteNode extends IsElementalNode {
   content: string;
   align?: Align;
   border_color?: string;
-  border_left_width?: number;
-  padding_horizontal?: number;
-  padding_vertical?: number;
   background_color?: string;
   /** CSS px value (e.g. "16px"). Overrides the `text_style` preset font size */
   font_size?: string;
@@ -351,6 +348,17 @@ export interface ElementalQuoteNode extends IsElementalNode {
   locales?: ElementalLocales<{
     content?: string;
   }>;
+  /**
+   * @deprecated Designer-only field that no render path reads, and that the
+   * designer exposes no control for. Read on load so quotes stored before
+   * C-19960 keep their frame in the editor; never emitted, so it is dropped on
+   * the next save.
+   */
+  border_left_width?: number | string;
+  /** @deprecated Designer-only field. Read-only, see `border_left_width` */
+  padding_horizontal?: number | string;
+  /** @deprecated Designer-only field. Read-only, see `border_left_width` */
+  padding_vertical?: number | string;
 }
 
 export interface ElementalHtmlNode extends IsElementalNode {


### PR DESCRIPTION
## What

The quote branch of `convertTiptapToElemental` wrote three fields on **every** quote:

| field | canonical equivalent |
| -- | -- |
| `border_left_width` | `border_size` |
| `padding_horizontal` | `padding` |
| `padding_vertical` | `padding` |

No render path reads them. The email renderer reads `border_size` / `padding` (`handlebars/partials/email/quote-block.hbs`, `elementalQuoteNodeToBlockWire`), and the backend `ElementalQuoteNode` declares only `border_color` / `border_size` / `padding`. The values came straight from the Blockquote attr defaults (`Blockquote.ts:55-63` — 20 / 4 / 2), because `BlockquoteForm.tsx` exposes no control for any of them.

## What changed

- **Stopped serializing them.** `convertTiptapToElemental.ts` quote branch emits nothing for the frame.
- **Still reads them on load.** `convertElementalToTiptap.ts` gets `readQuoteFrameAttrs` / `parseQuoteFrameValue`, replacing the inline spread. Quotes stored before this change keep their frame in the editor and are dropped on the next save. Tolerates the string-typed values present in stored content.
- **Types/schema keep the fields**, marked `@deprecated` read-only and widened to `number | string`, so existing content still validates.

They are **dropped rather than rewritten** into `border_size` / `padding`: the quote frame is not an authorable property in the designer, so translating it would persist a value no one can edit.

## Notes

- `@trycourier/react-designer` patch changeset included.
- Studio needs no change: `convertElementalToHTML.ts` already prefers `element.padding` and falls back to the same Blockquote defaults, and still reads the legacy triple for pre-existing content.
- Companion C-19961 covers `action.color` and the Inbox `buttonRow` style carrier, deliberately untouched here. Note for whoever picks it up: `style` is **not** a declared attr on the `button` TipTap node (`Button.ts:64-193`), so ProseMirror drops `attrs.style` on `setContent` — that has to be fixed before `style` can carry filled/outlined.

## Test plan

- Full vitest suite: **2939 passed** (was 2929; 10 new tests across both converters).
- `typecheck:src` and `lint:src` clean.
- Regression cycle run: reintroducing the old emission fails 4 of the new tests; restoring the fix makes them pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
