### PR TITLE
feat(designer): let hosts opt out of the View Preview button [C-20012]

### DIFF
--- a/.changeset/quiet-preview-pill.md
+++ b/.changeset/quiet-preview-pill.md
@@ -1,0 +1,18 @@
+---
+"@trycourier/react-designer": patch
+---
+
+Add `previewPanelEnabled` to `TemplateProvider`, letting a host suppress `PreviewPanel`'s
+"View Preview" / "Exit Preview" button. It defaults to `true`, so nothing changes for existing
+hosts; a `PreviewPanel` rendered outside any provider is unaffected.
+
+`PreviewPanel` floats a pill over the editing canvas whose only content, before a preview mode
+is picked, is that button. A host that drives preview from its own chrome — a "Preview and test"
+screen, say — was left with redundant overlay it could not turn off, since `hideExitButton` is a
+per-call-site prop on the panel rather than something the host configures once.
+
+When the flag is `false` the button is dropped but the desktop/mobile toggle still renders
+whenever a `previewMode` is already active, so a preview screen keeps its toggle. The panel also
+returns `null` when neither the button nor the toggle would render, instead of leaving an empty
+pill floating over the canvas — previously reachable through `hideExitButton` with no
+`previewMode` set.

--- a/docs/summaries/handoff-2026-08-18-C-20012-execute.md
+++ b/docs/summaries/handoff-2026-08-18-C-20012-execute.md
@@ -1,0 +1,80 @@
+# Session Handoff: Host opt-out for the PreviewPanel "View Preview" button
+
+**Date:** 2026-08-18
+**Session Duration:** one session — implement in `courier-designer`, vendor into `frontend`
+**Session Focus:** C-20012. Give hosts a provider-level switch that removes the floating "View Preview" pill from the editing canvas, without removing the capability from the designer itself.
+**Context Usage at Handoff:** low
+
+## What Was Accomplished
+
+1. New atom `previewPanelEnabledAtom` (default `true`) → `packages/react-designer/src/components/TemplateEditor/store.ts`
+2. New `previewPanelEnabled?: boolean` prop on `TemplateProvider`, synced into that atom → `packages/react-designer/src/components/Providers/TemplateProvider.tsx`
+3. `PreviewPanel` reads the atom and returns `null` when it has nothing to render → `packages/react-designer/src/components/ui/PreviewPanel/PreviewPanel.tsx`
+4. Test updates + 3 new cases → `packages/react-designer/src/components/ui/PreviewPanel/PreviewPanel.test.tsx`
+5. `patch` changeset → `.changeset/quiet-preview-pill.md`
+
+Commit: `0b7ca899` on `geraldosilva/c-20012-remove-hover-view-preview-overlay-in-template-designer`, branched from `main` at `9e9b91a3`.
+
+## Exact State of Work in Progress
+
+Nothing mid-stream. The corresponding frontend change is a separate PR that vendors this branch's `dist`; see that repo's handoff (`docs/summaries/handoff-2026-08-18-C-20012-vendor.md` in `frontend`).
+
+## Decisions Made This Session
+
+- **Prop, not a hard removal**, BECAUSE courier-designer keeps offering the button to other hosts — studio is the one host that does not want it. STATUS: confirmed with the user.
+- **The flag gates the button, not the whole panel** BECAUSE studio's "Preview and Test" screen must keep the desktop/mobile toggle. So with `previewPanelEnabled={false}`: the View/Exit Preview button is always dropped, and the toggle still renders whenever a `previewMode` is already active. STATUS: confirmed with the user.
+- **Positive-boolean naming** (`previewPanelEnabled`, default `true`) BECAUSE it matches the provider's existing `linkTrackingEnabled` / `emailFormattingEnabled` / `variablesEnabled`, rather than the channel-level `hideExitButton` / `hidePreviewPanelExitButton` negatives. STATUS: confirmed with the user.
+- **Empty-pill fix rides along**: the panel now returns `null` when neither the button nor the toggle would render. Previously `hideExitButton` + no `previewMode` produced a visible empty floating pill. STATUS: confirmed — no caller relied on it (the one test asserting it was rewritten).
+
+## Key Numbers Generated or Discovered This Session
+
+- `PreviewPanel` suite: 41 tests pass (38 before; 1 rewritten, 3 added).
+- `Providers` + `Channels/Email` suites: 136 tests pass.
+- `pnpm run typecheck:src`: exit 0. `pnpm run typecheck` (which includes test files) fails on ~40 **pre-existing** errors in unrelated `*.test.ts*` files — none in the files touched here.
+- `eslint` on the four touched paths: clean.
+
+## Conditional Logic Established
+
+- IF `previewPanelEnabled` is `false` AND `previewMode` is undefined THEN `PreviewPanel` renders nothing at all BECAUSE an empty pill still overlays the canvas.
+- IF `previewPanelEnabled` is `false` AND `previewMode` is set THEN the desktop/mobile toggle still renders BECAUSE preview surfaces ("Preview and Test", version history, comparison) need it.
+- IF a `PreviewPanel` is rendered outside any `TemplateProvider` THEN the atom default (`true`) applies, so behaviour is unchanged.
+
+## Files Created or Modified
+
+| File Path | Action | Description |
+|-----------|--------|-------------|
+| `packages/react-designer/src/components/TemplateEditor/store.ts` | Modified | Added `previewPanelEnabledAtom` (default `true`) beside the other host feature-flag atoms |
+| `packages/react-designer/src/components/Providers/TemplateProvider.tsx` | Modified | Added the `previewPanelEnabled` prop, its JSDoc, and the effect that syncs it into the atom |
+| `packages/react-designer/src/components/ui/PreviewPanel/PreviewPanel.tsx` | Modified | Reads the atom; computes `showExitButton` / `showModeToggle`; returns `null` when both are false |
+| `packages/react-designer/src/components/ui/PreviewPanel/PreviewPanel.test.tsx` | Modified | Rewrote the empty-pill assertion; added a `previewPanelEnabled` describe block (canvas hidden / toggle kept / default on) |
+| `.changeset/quiet-preview-pill.md` | Created | `patch` changeset for `@trycourier/react-designer` covering the new prop and the null-render fix |
+| `docs/summaries/handoff-2026-08-18-C-20012-execute.md` | Created | This handoff |
+
+## What the NEXT Session Should Do
+
+1. **First**: land the designer PR, then the frontend PR — the frontend's vendored `dist` is built from this branch and exists nowhere else, so it must not merge first.
+2. **Then**: nothing else here. No follow-up work is owed in this repo.
+
+## Follow-ups (consolidated)
+
+### Immediate
+- [ ] Merge order: designer PR before the frontend vendor PR.
+
+### Carried forward
+- **OPEN:** none.
+
+## Open Questions Requiring User Input
+
+- None.
+
+## Assumptions That Need Validation
+
+- **ASSUMED:** studio is the only host that wants the button off — every other consumer keeps the default. Validate by the fact that the prop is opt-out and defaults to `true`.
+
+## What NOT to Re-Read
+
+- `packages/react-designer/src/components/ui/PreviewPanel/PreviewPanel.tsx` — the whole change is summarized above.
+
+## Files to Load Next Session
+
+- `packages/react-designer/src/components/Providers/TemplateProvider.tsx` — needed if another host-level flag is added; follow the same atom + effect shape.

--- a/packages/react-designer/src/components/Providers/TemplateProvider.tsx
+++ b/packages/react-designer/src/components/Providers/TemplateProvider.tsx
@@ -15,6 +15,7 @@ import {
   disableVariablesAutocompleteAtom,
   emailFormattingEnabledAtom,
   linkTrackingEnabledAtom,
+  previewPanelEnabledAtom,
   sampleDataAtom,
   variablesEnabledAtom,
   variableValidationAtom,
@@ -66,6 +67,16 @@ type TemplateProviderProps = BasicProviderProps & {
    */
   emailFormattingEnabled?: boolean;
   /**
+   * Whether the `PreviewPanel`'s "View Preview" / "Exit Preview" button is
+   * offered. When false the button is dropped, and the panel renders nothing at
+   * all unless a `previewMode` is already active (in which case it still shows
+   * the desktop/mobile toggle — so a "Preview and test" screen keeps its
+   * toggle). Turn it off when the host drives preview from its own chrome and
+   * does not want the floating pill overlaying the editing canvas.
+   * @default true
+   */
+  previewPanelEnabled?: boolean;
+  /**
    * Whether the designer should render its own Sonner `<Toaster />`.
    * Set to `false` when the host app already provides one to avoid duplicate toasts.
    * @default true
@@ -87,6 +98,7 @@ const TemplateProviderContext: React.FC<TemplateProviderProps> = ({
   sampleData,
   linkTrackingEnabled = true,
   emailFormattingEnabled = false,
+  previewPanelEnabled = true,
   renderToaster = true,
 }) => {
   const [, setApiUrl] = useAtom(apiUrlAtom);
@@ -99,6 +111,7 @@ const TemplateProviderContext: React.FC<TemplateProviderProps> = ({
   const [, setVariablesEnabled] = useAtom(variablesEnabledAtom);
   const [, setLinkTrackingEnabled] = useAtom(linkTrackingEnabledAtom);
   const [, setEmailFormattingEnabled] = useAtom(emailFormattingEnabledAtom);
+  const [, setPreviewPanelEnabled] = useAtom(previewPanelEnabledAtom);
   const [, setVariableValidation] = useAtom(variableValidationAtom);
   const [, setSampleData] = useAtom(sampleDataAtom);
   const [, setRenderToaster] = useAtom(renderToasterAtom);
@@ -141,6 +154,11 @@ const TemplateProviderContext: React.FC<TemplateProviderProps> = ({
   useEffect(() => {
     setEmailFormattingEnabled(emailFormattingEnabled ?? false);
   }, [emailFormattingEnabled, setEmailFormattingEnabled]);
+
+  // Sync whether the preview panel's View/Exit Preview button is offered
+  useEffect(() => {
+    setPreviewPanelEnabled(previewPanelEnabled ?? true);
+  }, [previewPanelEnabled, setPreviewPanelEnabled]);
 
   // Sync variable validation config (only when explicitly provided, so that
   // TemplateEditor's own variableValidation prop isn't overwritten by a parent

--- a/packages/react-designer/src/components/TemplateEditor/store.ts
+++ b/packages/react-designer/src/components/TemplateEditor/store.ts
@@ -131,6 +131,15 @@ export const linkTrackingEnabledAtom = atom<boolean>(true);
 // not symmetric. Set through `TemplateProvider`'s `emailFormattingEnabled`.
 export const emailFormattingEnabledAtom = atom<boolean>(false);
 
+// Atom to control whether the `PreviewPanel`'s "View Preview" / "Exit Preview"
+// button is offered. When false the button is dropped, and the panel renders
+// nothing at all unless it still has the desktop/mobile toggle to show (i.e.
+// unless a `previewMode` is already active). Hosts that drive preview from their
+// own chrome — a "Preview and test" screen, say — turn it off so the floating
+// pill stops overlaying the editing canvas. Set through `TemplateProvider`'s
+// `previewPanelEnabled`.
+export const previewPanelEnabledAtom = atom<boolean>(true);
+
 // Atom to store available variables for autocomplete suggestions
 // This is populated from the `variables` prop passed to TemplateEditor/BrandEditor
 export const availableVariablesAtom = atom<Record<string, unknown>>({});

--- a/packages/react-designer/src/components/ui/PreviewPanel/PreviewPanel.test.tsx
+++ b/packages/react-designer/src/components/ui/PreviewPanel/PreviewPanel.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { createStore, Provider } from "jotai";
+import { previewPanelEnabledAtom } from "@/components/TemplateEditor/store";
 import { PreviewPanel } from "./PreviewPanel";
 
 describe("PreviewPanel", () => {
@@ -236,7 +238,7 @@ describe("PreviewPanel", () => {
   });
 
   describe("Props Combinations", () => {
-    it("should handle hideExitButton and hideMobileToggle both true", () => {
+    it("should render nothing when hideExitButton and hideMobileToggle are both true", () => {
       const { container } = render(
         <PreviewPanel
           previewMode="desktop"
@@ -246,8 +248,8 @@ describe("PreviewPanel", () => {
         />
       );
 
-      const panel = container.firstChild as HTMLElement;
-      expect(panel).toBeInTheDocument();
+      // Nothing left to show, so no empty pill is left overlaying the canvas.
+      expect(container).toBeEmptyDOMElement();
       expect(screen.queryAllByRole("button")).toHaveLength(0);
       expect(screen.queryAllByRole("radio")).toHaveLength(0);
     });
@@ -436,6 +438,39 @@ describe("PreviewPanel", () => {
       const panel = container.firstChild as HTMLElement;
       expect(panel).toHaveAttribute("id", "preview-panel");
       expect(panel).toHaveAttribute("aria-label", "Preview panel");
+    });
+  });
+
+  describe("previewPanelEnabled (TemplateProvider opt-out)", () => {
+    const renderDisabled = (previewMode: "desktop" | "mobile" | undefined) => {
+      const store = createStore();
+      store.set(previewPanelEnabledAtom, false);
+
+      return render(
+        <Provider store={store}>
+          <PreviewPanel previewMode={previewMode} togglePreviewMode={mockTogglePreviewMode} />
+        </Provider>
+      );
+    };
+
+    it("should render nothing on the editing canvas when disabled", () => {
+      const { container } = renderDisabled(undefined);
+
+      expect(container).toBeEmptyDOMElement();
+      expect(screen.queryByRole("button", { name: /view preview/i })).not.toBeInTheDocument();
+    });
+
+    it("should keep the desktop/mobile toggle when a preview mode is active", () => {
+      renderDisabled("desktop");
+
+      expect(screen.getAllByRole("radio")).toHaveLength(2);
+      expect(screen.queryByRole("button", { name: /exit preview/i })).not.toBeInTheDocument();
+    });
+
+    it("should render the View Preview button when enabled (default)", () => {
+      render(<PreviewPanel previewMode={undefined} togglePreviewMode={mockTogglePreviewMode} />);
+
+      expect(screen.getByRole("button", { name: /view preview/i })).toBeInTheDocument();
     });
   });
 });

--- a/packages/react-designer/src/components/ui/PreviewPanel/PreviewPanel.tsx
+++ b/packages/react-designer/src/components/ui/PreviewPanel/PreviewPanel.tsx
@@ -1,7 +1,9 @@
+import { previewPanelEnabledAtom } from "@/components/TemplateEditor/store";
 import { Button } from "@/components/ui-kit/Button/Button";
 import { DesktopIcon, MobileIcon } from "@/components/ui-kit/Icon";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui-kit/ToggleGroup";
 import { cn } from "@/lib/utils";
+import { useAtomValue } from "jotai";
 import type { HTMLAttributes } from "react";
 
 interface PreviewPanelProps extends HTMLAttributes<HTMLDivElement> {
@@ -38,6 +40,19 @@ export const PreviewPanel = ({
   hideExitButton = false,
   ...props
 }: PreviewPanelProps) => {
+  // Host-level opt-out, set through `TemplateProvider`'s `previewPanelEnabled`.
+  // Defaults to true, so a `PreviewPanel` rendered outside a provider is
+  // unaffected.
+  const previewPanelEnabled = useAtomValue(previewPanelEnabledAtom);
+  const showExitButton = !hideExitButton && previewPanelEnabled;
+  const showModeToggle = Boolean(previewMode) && !hideMobileToggle;
+
+  // Nothing left to render — don't leave an empty floating pill overlaying the
+  // canvas.
+  if (!showExitButton && !showModeToggle) {
+    return null;
+  }
+
   return (
     <div
       {...props}
@@ -46,7 +61,7 @@ export const PreviewPanel = ({
         props.className
       )}
     >
-      {previewMode && !hideMobileToggle && (
+      {showModeToggle && (
         <>
           <ToggleGroup
             type="single"
@@ -62,12 +77,12 @@ export const PreviewPanel = ({
             <PreviewItem value="desktop" icon={<DesktopIcon />} />
             <PreviewItem value="mobile" icon={<MobileIcon />} />
           </ToggleGroup>
-          {!hideExitButton && (
+          {showExitButton && (
             <div className="courier-mx-4 courier-w-px courier-h-6 courier-bg-border" />
           )}
         </>
       )}
-      {!hideExitButton && (
+      {showExitButton && (
         <Button variant="link" onClick={() => togglePreviewMode()}>
           {previewMode ? "Exit" : "View"} Preview
         </Button>


### PR DESCRIPTION
## What

`PreviewPanel` floats a pill over the editing canvas whose only content, before a preview mode is picked, is a "View Preview" button. Studio drives preview from its own header chrome ("Preview and test", cross-client preview), so there the pill is redundant overlay — but other hosts still want the button, so it is not going away.

- New `previewPanelEnabled` prop on `TemplateProvider`, **default `true`** — nothing changes for existing hosts. Backed by `previewPanelEnabledAtom`, same shape as `linkTrackingEnabled` / `emailFormattingEnabled`.
- When `false`, `PreviewPanel` drops the View/Exit Preview button but **keeps the desktop/mobile toggle whenever a `previewMode` is already active** — a "Preview and test" screen still gets its toggle.
- The panel now returns `null` when it has nothing to render, instead of leaving an empty pill floating over the canvas (the old `hideExitButton` + no `previewMode` case).

## Tests

- `PreviewPanel`: 41 pass — one rewritten (it asserted the empty pill), three added for the new flag.
- `Providers` + `Channels/Email`: 136 pass.
- `typecheck:src` and `eslint` on the touched paths: clean.

## Linear

C-20012: Remove hover "View Preview" overlay in template designer
https://linear.app/trycourier/issue/C-20012/remove-hover-view-preview-overlay-in-template-designer

## ADRs

None

## Open Items

The frontend side is a separate PR that vendors this branch's `dist` — **land this one first**.