### PR TITLE
fix(email): let the numeric style fields be emptied while typing [C-20044]

### DIFF
--- a/.changeset/emptiable-number-fields.md
+++ b/.changeset/emptiable-number-fields.md
@@ -1,0 +1,10 @@
+---
+"@trycourier/react-designer": patch
+---
+
+Let the email style number fields be emptied while typing. Font size, line spacing (document
+and block level) and frame padding were controlled straight from the stored value, so clearing
+one re-derived the same number and pushed it back into the box — backspacing 13 left a 1 that
+refused to delete, and typing 23 over it was impossible. The new `NumberInput` keeps the typed
+text while the field is focused, commits every keystroke so the canvas still updates live, and
+restores a real value on blur.

--- a/docs/summaries/handoff-2026-08-19-C-20044-execute.md
+++ b/docs/summaries/handoff-2026-08-19-C-20044-execute.md
@@ -1,0 +1,52 @@
+# Session Handoff: Numeric style fields can be emptied while typing
+
+**Date:** 2026-08-19
+**Session Duration:** one session — implement in `courier-designer`, vendor into `frontend`
+**Session Focus:** C-20044. The email formatting number inputs (font size, line spacing, frame padding) could not be cleared, so any value below 10 was impossible to type.
+**Context Usage at Handoff:** low
+
+## What Was Accomplished
+
+1. New `NumberInput` → `packages/react-designer/src/components/ui-kit/Input/NumberInput.tsx`, exported from `ui-kit/Input`. It holds the typed text in a draft while the field is being edited, commits on every keystroke, and drops the draft on blur.
+2. Block-level font size / line spacing switched to it → `packages/react-designer/src/components/extensions/shared/TypographyFields.tsx`. `toValue` now takes `number | null` instead of the raw string.
+3. Document-level base text and frame padding switched to it → `packages/react-designer/src/components/TemplateEditor/Channels/Email/EmailDocumentStyleFields.tsx`. `parsePaddingInput` is gone, replaced by `commitEmpty={false}` on the two padding fields.
+4. Tests: `NumberInput.test.tsx` (7 cases) and 2 regression cases in `TypographyFields.test.tsx` that drive a stateful host, which is what exposes the loop.
+5. `patch` changeset → `.changeset/emptiable-number-fields.md`
+
+Branch `geraldosilva/c-20044-fix-numeric-input-entry-behavior`, branched from `main` at `9e9b91a3`.
+
+## Exact State of Work in Progress
+
+Nothing mid-stream. The frontend side is a separate PR that vendors this branch's `dist`; see `docs/summaries/handoff-2026-08-19-C-20044-vendor.md` in `frontend`.
+
+## Decisions Made This Session
+
+**The bug is the controlled round trip, not the validation.** `value={fontSize ?? inheritedFontSize}` plus "empty means unset" means an empty field immediately re-derives the inherited number and renders it. Draft state is the only thing that breaks the loop while keeping the canvas live; committing on blur alone would have cost the real-time preview the feature was built for.
+
+**Empty still commits `null` for typography** — that is the existing "inherit" state, so the canvas falls back to the document base (or tier preset) exactly as the Reset link produces. The field showing blank is a transient editing state; blur always restores a real number, so nothing can be left blank.
+
+**Frame padding opts out of committing empty (`commitEmpty={false}`)** BECAUSE padding has no per-side unset state — the stored value is a `vertical horizontal` shorthand, and there is no way to unset one side. Committing `null` would either persist a `0` the author never chose or drop the whole override including the other side. Emptying a padding field therefore leaves the stored value alone until a number arrives, and blur restores it. STATUS: flagged to the user; revisit if per-side reset is ever wanted.
+
+**`FontSizeButton` (text bubble menu) was left alone** BECAUSE it was already draft-based (commits on blur/Enter), so it never had the bug.
+
+## Key Numbers Generated or Discovered This Session
+
+- Full suite: 2959 pass, 0 fail (2962 with the two open PRs stacked in for the vendored build).
+- `pnpm run typecheck:src`: exit 0. `pnpm run typecheck` still fails on the same ~40 **pre-existing** errors in unrelated `*.test.ts*` files.
+- `eslint` clean on the touched paths. Repo-wide `pnpm lint` still fails on the pre-existing `build.js` tsconfig error.
+
+## Regression Cycle (per the repo's test rule)
+
+With the fix rolled back to `value={String(value)}`, 4 of the new tests fail; restored, 18/18 pass. The tests do detect the regression.
+
+## Conditional Logic Established
+
+- IF the field is focused and empty AND `commitEmpty` THEN the override is dropped and the canvas renders the inherited/default value.
+- IF the field is focused and empty AND NOT `commitEmpty` (frame padding) THEN nothing is committed and the stored value stands.
+- IF the entry is unparseable ("-", "1e") THEN it stays on screen uncommitted, so the canvas keeps the last real value.
+- IF the field blurs THEN the draft is dropped, so the box always shows the value the caller supplies.
+
+## Related
+
+- Frontend vendor PR handoff: `docs/summaries/handoff-2026-08-19-C-20044-vendor.md` in `frontend`
+- Linear: https://linear.app/trycourier/issue/C-20044

--- a/packages/react-designer/src/components/TemplateEditor/Channels/Email/EmailDocumentStyleFields.tsx
+++ b/packages/react-designer/src/components/TemplateEditor/Channels/Email/EmailDocumentStyleFields.tsx
@@ -1,4 +1,4 @@
-import { Button, Input } from "@/components/ui-kit";
+import { Button, NumberInput } from "@/components/ui-kit";
 import {
   FontSizeIcon,
   LineHeightIcon,
@@ -32,18 +32,12 @@ const defaultInfoIcon = () => (
 );
 
 /**
- * A padding edit, or null when the field is mid-edit and empty.
- *
- * Clearing the field to retype must not persist `0` — that would queue an
- * autosave for a value the author never chose. The typography fields treat empty
- * the same way (as "unset"); padding has no unset state per-side, so an empty
- * field simply leaves the stored value alone until a number arrives.
+ * Padding has no unset state per side, so an empty field cannot commit: `0`
+ * would persist a value the author never chose. `NumberInput` keeps the box
+ * empty while it is being retyped and restores the stored number on blur, so
+ * nothing is written until a number arrives.
  */
-const parsePaddingInput = (raw: string): number | null => {
-  if (raw.trim() === "") return null;
-  const parsed = Number(raw);
-  return Number.isFinite(parsed) ? Math.max(0, parsed) : null;
-};
+const PADDING_COMMIT_EMPTY = false;
 
 /**
  * The reset affordance for a document-level section. A subdued text link rather
@@ -112,30 +106,30 @@ export const EmailFramePaddingFields = ({
       </div>
       <div className="courier-flex courier-flex-row courier-gap-3 courier-mb-4">
         <div className="courier-flex-1">
-          <Input
+          <NumberInput
             startAdornment={<PaddingHorizontalIcon />}
-            type="number"
             min={0}
             aria-label="Horizontal padding"
             data-testid="email-frame-padding-horizontal"
+            commitEmpty={PADDING_COMMIT_EMPTY}
             value={documentStyles.emailPaddingHorizontal}
-            onChange={(e) => {
-              const horizontal = parsePaddingInput(e.target.value);
-              if (horizontal !== null) documentStyles.handlePaddingChange({ horizontal });
+            onValueChange={(typed) => {
+              if (typed === null) return;
+              documentStyles.handlePaddingChange({ horizontal: Math.max(0, typed) });
             }}
           />
         </div>
         <div className="courier-flex-1">
-          <Input
+          <NumberInput
             startAdornment={<PaddingVerticalIcon />}
-            type="number"
             min={0}
             aria-label="Vertical padding"
             data-testid="email-frame-padding-vertical"
+            commitEmpty={PADDING_COMMIT_EMPTY}
             value={documentStyles.emailPaddingVertical}
-            onChange={(e) => {
-              const vertical = parsePaddingInput(e.target.value);
-              if (vertical !== null) documentStyles.handlePaddingChange({ vertical });
+            onValueChange={(typed) => {
+              if (typed === null) return;
+              documentStyles.handlePaddingChange({ vertical: Math.max(0, typed) });
             }}
           />
         </div>
@@ -187,35 +181,25 @@ export const EmailBaseTypographyFields = ({
       </div>
       <div className="courier-flex courier-flex-row courier-gap-3 courier-mb-4">
         <div className="courier-flex-1">
-          <Input
+          <NumberInput
             startAdornment={<FontSizeIcon className={ADORNMENT_ICON} />}
-            type="number"
             min={0}
             max={MAX_FONT_SIZE}
             aria-label="Base font size"
             data-testid="email-document-font-size"
             value={documentStyles.emailFontSizeValue}
-            onChange={(e) =>
-              documentStyles.handleFontSizeChange(
-                e.target.value.trim() === "" ? null : Number(e.target.value)
-              )
-            }
+            onValueChange={documentStyles.handleFontSizeChange}
           />
         </div>
         <div className="courier-flex-1">
-          <Input
+          <NumberInput
             startAdornment={<LineHeightIcon className={ADORNMENT_ICON} />}
-            type="number"
             min={0}
             max={MAX_LINE_HEIGHT}
             aria-label="Base line spacing"
             data-testid="email-document-line-height"
             value={documentStyles.emailLineHeightValue}
-            onChange={(e) =>
-              documentStyles.handleLineHeightChange(
-                e.target.value.trim() === "" ? null : Number(e.target.value)
-              )
-            }
+            onValueChange={documentStyles.handleLineHeightChange}
           />
         </div>
       </div>

--- a/packages/react-designer/src/components/extensions/shared/TypographyFields.test.tsx
+++ b/packages/react-designer/src/components/extensions/shared/TypographyFields.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { Provider, createStore } from "jotai";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { emailFormattingEnabledAtom } from "@/components/TemplateEditor/store";
 import { MAX_FONT_SIZE, MAX_LINE_HEIGHT } from "@/lib/constants/typography-limits";
 import { TypographyFields } from "./TypographyFields";
@@ -19,6 +19,25 @@ const renderFields = (ui: ReactNode) => {
 
 const fontSizeInput = () => screen.getByTestId("typography-font-size") as HTMLInputElement;
 const lineHeightInput = () => screen.getByTestId("typography-line-height") as HTMLInputElement;
+
+/**
+ * The block as it actually behaves: the override the field commits comes back in
+ * as the value, and clearing it drops back to the inherited size. Static props
+ * would hide the loop that used to make the field impossible to empty.
+ */
+const StatefulFields = ({ inheritedFontSize = 13 }: { inheritedFontSize?: number }) => {
+  const [fontSize, setFontSize] = useState<number | null>(null);
+  return (
+    <TypographyFields
+      fontSize={fontSize}
+      lineHeight={null}
+      inheritedFontSize={inheritedFontSize}
+      inheritedLineHeight={15}
+      onFontSizeChange={setFontSize}
+      onLineHeightChange={vi.fn()}
+    />
+  );
+};
 
 describe("TypographyFields", () => {
   it("seeds both fields from the inherited values when the block sets nothing", () => {
@@ -189,5 +208,33 @@ describe("TypographyFields", () => {
 
     expect(fontSizeInput().value).toBe("14");
     expect(screen.queryByTestId("typography-line-height")).not.toBeInTheDocument();
+  });
+
+  it("can be emptied and retyped below the inherited size", () => {
+    renderFields(<StatefulFields />);
+
+    fireEvent.change(fontSizeInput(), { target: { value: "1" } });
+    fireEvent.change(fontSizeInput(), { target: { value: "" } });
+    expect(fontSizeInput().value).toBe("");
+
+    fireEvent.change(fontSizeInput(), { target: { value: "2" } });
+    fireEvent.change(fontSizeInput(), { target: { value: "23" } });
+    expect(fontSizeInput().value).toBe("23");
+
+    // Blur can only ever leave a real number behind.
+    fireEvent.blur(fontSizeInput());
+    expect(fontSizeInput().value).toBe("23");
+  });
+
+  it("falls back to the inherited size while the field is empty", () => {
+    renderFields(<StatefulFields />);
+
+    fireEvent.change(fontSizeInput(), { target: { value: "20" } });
+    fireEvent.change(fontSizeInput(), { target: { value: "" } });
+    // The override is gone, so the canvas renders the inherited size again...
+    expect(fontSizeInput().value).toBe("");
+    // ...and blurring shows that inherited size rather than an empty box.
+    fireEvent.blur(fontSizeInput());
+    expect(fontSizeInput().value).toBe("13");
   });
 });

--- a/packages/react-designer/src/components/extensions/shared/TypographyFields.tsx
+++ b/packages/react-designer/src/components/extensions/shared/TypographyFields.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@/components/ui-kit";
+import { NumberInput } from "@/components/ui-kit";
 import { FontSizeIcon, LineHeightIcon } from "@/components/ui-kit/Icon";
 import { Tooltip } from "@/components/ui/Tooltip";
 import { Info } from "lucide-react";
@@ -62,11 +62,9 @@ type TypographyFieldsProps = LineHeightProps & {
  * Anything above `max` is capped rather than rejected, so a typed or pasted 2000
  * lands on the ceiling instead of being dropped as if the field were empty.
  */
-const toValue = (raw: string, inherited: number, max: number): number | null => {
-  if (raw.trim() === "") return null;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return null;
-  const capped = clampTypographyValue(parsed, max);
+const toValue = (typed: number | null, inherited: number, max: number): number | null => {
+  if (typed === null || !Number.isFinite(typed) || typed <= 0) return null;
+  const capped = clampTypographyValue(typed, max);
   return capped === inherited ? null : capped;
 };
 
@@ -113,16 +111,15 @@ export const TypographyFields = ({
       </h4>
       <div className={`courier-flex courier-flex-row courier-gap-3 ${className ?? "courier-mb-4"}`}>
         <div className="courier-flex-1">
-          <Input
+          <NumberInput
             startAdornment={<FontSizeIcon className={ADORNMENT_ICON} />}
-            type="number"
             min={0}
             max={MAX_FONT_SIZE}
             aria-label="Font size"
             data-testid="typography-font-size"
             value={fontSize ?? inheritedFontSize}
-            onChange={(e) => {
-              const next = toValue(e.target.value, inheritedFontSize, MAX_FONT_SIZE);
+            onValueChange={(typed) => {
+              const next = toValue(typed, inheritedFontSize, MAX_FONT_SIZE);
               // Skip the no-op so clearing an already-inheriting field doesn't
               // queue an autosave for a change that isn't one.
               if (next === (fontSize ?? null)) return;
@@ -132,16 +129,15 @@ export const TypographyFields = ({
         </div>
         {showLineHeight && onLineHeightChange && inheritedLineHeight !== undefined && (
           <div className="courier-flex-1">
-            <Input
+            <NumberInput
               startAdornment={<LineHeightIcon className={ADORNMENT_ICON} />}
-              type="number"
               min={0}
               max={MAX_LINE_HEIGHT}
               aria-label="Line spacing"
               data-testid="typography-line-height"
               value={lineHeight ?? inheritedLineHeight}
-              onChange={(e) => {
-                const next = toValue(e.target.value, inheritedLineHeight, MAX_LINE_HEIGHT);
+              onValueChange={(typed) => {
+                const next = toValue(typed, inheritedLineHeight, MAX_LINE_HEIGHT);
                 if (next === (lineHeight ?? null)) return;
                 onLineHeightChange(next);
               }}

--- a/packages/react-designer/src/components/ui-kit/Input/NumberInput.test.tsx
+++ b/packages/react-designer/src/components/ui-kit/Input/NumberInput.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { NumberInput } from "./NumberInput";
+
+/**
+ * A host that behaves like the real callers: it stores the committed override
+ * and falls back to a default when there is none, so an empty field feeds the
+ * default straight back into `value`. That round trip is what used to make the
+ * field impossible to clear.
+ */
+const Host = ({
+  fallback = 13,
+  commitEmpty,
+  onCommit = vi.fn(),
+}: {
+  fallback?: number;
+  commitEmpty?: boolean;
+  onCommit?: (value: number | null) => void;
+}) => {
+  const [stored, setStored] = useState<number | null>(null);
+  return (
+    <NumberInput
+      aria-label="Size"
+      data-testid="size"
+      commitEmpty={commitEmpty}
+      value={stored ?? fallback}
+      onValueChange={(value) => {
+        setStored(value);
+        onCommit(value);
+      }}
+    />
+  );
+};
+
+const input = () => screen.getByTestId("size") as HTMLInputElement;
+
+describe("NumberInput", () => {
+  it("shows the value it is given while it is not being edited", () => {
+    render(<Host />);
+
+    expect(input().value).toBe("13");
+  });
+
+  it("stays empty when the author clears it, and commits the empty as unset", () => {
+    const onCommit = vi.fn();
+    render(<Host onCommit={onCommit} />);
+
+    fireEvent.change(input(), { target: { value: "" } });
+
+    expect(input().value).toBe("");
+    expect(onCommit).toHaveBeenCalledWith(null);
+  });
+
+  it("lets the author retype a smaller number over the seeded one", () => {
+    const onCommit = vi.fn();
+    render(<Host onCommit={onCommit} />);
+
+    // Backspacing 13 away, then typing 2 — the entry that used to be impossible
+    // because the field snapped back to 13 the moment it went empty.
+    fireEvent.change(input(), { target: { value: "1" } });
+    fireEvent.change(input(), { target: { value: "" } });
+    fireEvent.change(input(), { target: { value: "2" } });
+    fireEvent.change(input(), { target: { value: "23" } });
+
+    expect(input().value).toBe("23");
+    expect(onCommit).toHaveBeenLastCalledWith(23);
+  });
+
+  it("commits every keystroke so the canvas tracks the field live", () => {
+    const onCommit = vi.fn();
+    render(<Host onCommit={onCommit} />);
+
+    fireEvent.change(input(), { target: { value: "2" } });
+    fireEvent.change(input(), { target: { value: "23" } });
+
+    expect(onCommit.mock.calls).toEqual([[2], [23]]);
+  });
+
+  it("restores the value on blur, so the field is never left empty", () => {
+    render(<Host />);
+
+    fireEvent.change(input(), { target: { value: "" } });
+    fireEvent.blur(input());
+
+    expect(input().value).toBe("13");
+  });
+
+  it("keeps the stored value when empty cannot be committed", () => {
+    const onCommit = vi.fn();
+    render(<Host commitEmpty={false} onCommit={onCommit} />);
+
+    fireEvent.change(input(), { target: { value: "20" } });
+    fireEvent.change(input(), { target: { value: "" } });
+
+    expect(input().value).toBe("");
+    expect(onCommit.mock.calls).toEqual([[20]]);
+
+    fireEvent.blur(input());
+    expect(input().value).toBe("20");
+  });
+
+  it("still calls the caller's own blur handler", () => {
+    const onBlur = vi.fn();
+    render(
+      <NumberInput
+        aria-label="Size"
+        data-testid="size"
+        value={13}
+        onValueChange={vi.fn()}
+        onBlur={onBlur}
+      />
+    );
+
+    fireEvent.blur(input());
+
+    expect(onBlur).toHaveBeenCalled();
+  });
+});

--- a/packages/react-designer/src/components/ui-kit/Input/NumberInput.tsx
+++ b/packages/react-designer/src/components/ui-kit/Input/NumberInput.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import { Input, type InputProps } from "./Input";
+
+export interface NumberInputProps
+  extends Omit<InputProps, "value" | "onChange" | "type" | "defaultValue"> {
+  /**
+   * The number the field shows whenever it is not mid-edit — the stored value,
+   * or the value inherited/defaulted when nothing is stored.
+   */
+  value: number;
+  /**
+   * Called as the author types, so the canvas tracks the field live. `null`
+   * means the field is empty: the caller drops its override and the canvas falls
+   * back to whatever it renders without one.
+   */
+  onValueChange: (value: number | null) => void;
+  /**
+   * Whether an empty field commits `null`. Off for fields with no unset state
+   * (per-side frame padding), where emptying simply leaves the stored value
+   * alone until a number arrives.
+   */
+  commitEmpty?: boolean;
+}
+
+/**
+ * A numeric field the author can actually empty.
+ *
+ * A plain controlled `value={stored}` input cannot go blank: clearing it commits
+ * "unset", the caller re-derives the same number, and it is pushed straight back
+ * into the box — so backspacing 13 leaves a 1 that refuses to delete and typing
+ * 23 over it is impossible. Keeping the typed text in a draft while the field is
+ * being edited breaks that loop: what the author typed is what stays on screen,
+ * empty included, while every keystroke still commits so the canvas updates in
+ * real time.
+ *
+ * The draft is dropped on blur, so the field can only be left showing a real
+ * value — an empty field is a transient editing state, never a persisted one.
+ */
+export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
+  ({ value, onValueChange, commitEmpty = true, onBlur, ...props }, ref) => {
+    /** What the author typed, or null while the field is not being edited. */
+    const [draft, setDraft] = React.useState<string | null>(null);
+
+    return (
+      <Input
+        {...props}
+        ref={ref}
+        type="number"
+        value={draft ?? String(value)}
+        onChange={(e) => {
+          const raw = e.target.value;
+          setDraft(raw);
+
+          if (raw.trim() === "") {
+            if (commitEmpty) onValueChange(null);
+            return;
+          }
+          const parsed = Number(raw);
+          // A partial entry the browser cannot parse ("-", "1e") stays on screen
+          // without being committed, so the canvas keeps the last real value.
+          if (!Number.isFinite(parsed)) return;
+          onValueChange(parsed);
+        }}
+        onBlur={(e) => {
+          setDraft(null);
+          onBlur?.(e);
+        }}
+      />
+    );
+  }
+);
+
+NumberInput.displayName = "NumberInput";

--- a/packages/react-designer/src/components/ui-kit/Input/index.ts
+++ b/packages/react-designer/src/components/ui-kit/Input/index.ts
@@ -1,1 +1,2 @@
 export * from "./Input";
+export * from "./NumberInput";


### PR DESCRIPTION
## What

The email formatting number inputs — document-level base font size and line spacing, the per-block overrides, and the frame padding — could not be emptied. Backspacing the seeded `13` left a `1` that refused to delete, so typing anything below 10 (or retyping `23` over `13`) was impossible.

The fields were controlled straight from the stored value, with an empty field committing "unset". Clearing one therefore re-derived the same number and pushed it straight back into the box.

## How

New `NumberInput` (`ui-kit/Input/NumberInput.tsx`) keeps the typed text in a draft while the field is being edited, so what the author types is what stays on screen — empty included — while every keystroke still commits and the canvas updates live. The draft is dropped on blur, so the field can only be left showing a real value.

- `TypographyFields` (block-level size / line spacing) and `EmailDocumentStyleFields` (document base + frame) now use it.
- An empty typography field still means "inherit": the override is dropped and the canvas renders the document base or tier preset.
- Frame padding opts out of committing empty (`commitEmpty={false}`) because padding has no per-side unset state — the stored value is left alone until a number arrives, and blur restores it.
- `FontSizeButton` in the text bubble menu was already draft-based and is untouched.

## Testing

- `NumberInput.test.tsx` — 7 cases, driven through a stateful host that reproduces the round trip.
- 2 regression cases added to `TypographyFields.test.tsx`.
- Rollback cycle: with the draft reverted to `value={String(value)}`, 4 of the new tests fail; restored, all pass.
- Full suite 2959 pass, `typecheck:src` exit 0, eslint clean on the touched paths.

## Linear

https://linear.app/trycourier/issue/C-20044