### PR TITLE
docs: require a changeset on every packages/* PR

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -58,7 +58,10 @@ jobs:
 
   e2e-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # The suite itself runs ~20 min. A cold Playwright cache adds ~5 min more
+    # (GH caches are branch-scoped, so the first run on a new branch always
+    # misses), which used to blow a 25 min budget. 45 leaves real headroom.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
@@ -97,6 +100,8 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: cd packages/react-designer && npx playwright install chromium --with-deps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,14 @@ pnpm release                    # Build and publish packages
 pnpm release:canary             # Publish canary version
 ```
 
+**Every PR that changes `packages/*` must include a changeset** — a file under
+`.changeset/` naming the package and the bump (`patch` / `minor` / `major`) and
+describing the change in prose. Without one the release workflow ships nothing:
+the package version never moves, so the fix never reaches npm and never reaches
+the hosts that vendor a built `dist` (frontend/studio keys its caches on that
+version string). Add it in the same commit as the change, not as a follow-up.
+Docs-, CI- and test-only PRs are the only ones that legitimately skip it.
+
 ## Architecture
 
 ### Layered Structure


### PR DESCRIPTION
## What

`CLAUDE.md` documents the Changesets commands but never says a changeset is required. Spell out the rule.

A `packages/*` PR merged without a changeset releases nothing — the package version never moves, so the change reaches neither npm nor the hosts that vendor a built `dist` and key their caches on that version string. Docs-, CI- and test-only PRs still legitimately skip it.

## Why the CI change rides along

The e2e job was cancelled at its 25 minute limit twice on this branch — the suite runs ~20 minutes and a cold Playwright cache (GH caches are branch-scoped, so every new branch misses) adds ~5 more. So this PR also carries the timeout bump to 45 minutes and the cache restore-key, the same change as #201. Without it a docs-only PR cannot go green.

No source or behavior change.