### PR TITLE
ci: disable the Playwright e2e job on PRs [C-20083]

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -56,7 +56,13 @@ jobs:
             echo "Coverage report not found" >> $GITHUB_STEP_SUMMARY
           fi
 
+  # Disabled on CI (C-20083): the Playwright suite runs ~20 min per PR and is
+  # flaky against the dev app, so it blocked merges without catching real
+  # regressions. Run it locally instead:
+  #   pnpm --filter @trycourier/react-designer test:e2e
+  # To re-enable, remove the `if: false` below.
   e2e-test:
+    if: false
     runs-on: ubuntu-latest
     # The suite itself runs ~20 min. A cold Playwright cache adds ~5 min more
     # (GH caches are branch-scoped, so the first run on a new branch always

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,10 @@ For components that render in email:
 ## Testing
 
 - Unit tests: Vitest (run with `pnpm test` or `pnpm test:watch`)
-- E2E tests: Playwright (run with `pnpm test:e2e`)
+- E2E tests: Playwright (run with `pnpm test:e2e`) — **local only**. The
+  `e2e-test` job in `.github/workflows/check-pull-request.yml` is gated behind
+  `if: false` (C-20083): ~20 min per PR and flaky, so it blocked merges without
+  catching real regressions. To re-enable, remove the `if: false`.
 - Test files colocated with source files (e.g., `Component.test.tsx`)
 - Write tests for utility functions and component behavior
 - Test email rendering compatibility for email-specific features

--- a/docs/summaries/handoff-2026-08-20-C-20083-execute.md
+++ b/docs/summaries/handoff-2026-08-20-C-20083-execute.md
@@ -1,0 +1,32 @@
+# Session Handoff: Disable the Playwright e2e job on CI
+
+**Date:** 2026-08-20
+**Session Duration:** one short session
+**Session Focus:** C-20083. The `e2e-test` job in `check-pull-request.yml` ran ~20 min per PR and failed flakily against the dev app, blocking merges without catching real regressions. Gate it off, matching how `full-cycle-e2e-test` was already handled.
+**Context Usage at Handoff:** low
+
+## What Was Accomplished
+
+1. `if: false` on the `e2e-test` job, with a comment naming the ticket, the reason, the local command, and how to re-enable → `.github/workflows/check-pull-request.yml:59-66`. The job body is left intact so re-enabling is a one-line revert.
+2. Documented the state in the Testing section → `CLAUDE.md:178-181`, so the next session does not assume Playwright is a CI gate.
+
+`unit-test` is untouched and remains the only test gate on PRs.
+
+Branch `geraldosilva/c-20083-disable-e2e-for-courier-designer`, branched from `main` at `ec65d9fb`.
+
+## Exact State of Work in Progress
+
+Nothing mid-stream.
+
+## Decisions Made This Session
+
+**`if: false` rather than deleting the job or moving it to a schedule.** This is the precedent already set in this file by `full-cycle-e2e-test` (C-19520): the steps, the caching, and the env wiring stay on disk, so re-enabling costs one line instead of a reconstruction. A `workflow_dispatch`/nightly trigger would keep the flakiness, just on a different clock — and nobody is watching that clock. Local runs stay the intended path (`pnpm --filter @trycourier/react-designer test:e2e`).
+
+**Job removed as a check, not renamed.** With `if: false` the job reports as skipped rather than disappearing, which keeps any branch-protection rule that names `e2e-test` satisfiable instead of permanently pending.
+
+**No changeset.** CI- and docs-only change; nothing under `packages/*` moves, so the release rule in `CLAUDE.md` does not apply.
+
+## Related
+
+- Prior art in the same file: `full-cycle-e2e-test`, disabled under C-19520
+- Linear: https://linear.app/trycourier/issue/C-20083


### PR DESCRIPTION
## Summary

The `e2e-test` job took ~20 minutes per pull request and failed intermittently against the dev app, so it blocked merges without catching real regressions. This gates it off.

## Changes

- `if: false` on `e2e-test` in `.github/workflows/check-pull-request.yml`, with a comment naming the ticket, the reason, the local command, and how to re-enable.
- Recorded the state in the Testing section of `CLAUDE.md` so the next session does not assume Playwright is a CI gate.

## Why `if: false`

Same precedent as `full-cycle-e2e-test` (C-19520) in this file: the steps, caching and env wiring stay on disk, so re-enabling is a one-line revert. The job also reports as *skipped* rather than disappearing, which keeps any branch-protection rule naming `e2e-test` satisfiable instead of permanently pending.

A nightly or `workflow_dispatch` trigger was considered and rejected — it keeps the flakiness, just on a clock nobody watches.

## Testing

Run the suite locally:

```
pnpm --filter @trycourier/react-designer test:e2e
```

`unit-test` is untouched and remains the test gate on PRs.

## Changeset

None — CI- and docs-only, nothing under `packages/*` changes.

Linear: [C-20083](https://linear.app/trycourier/issue/C-20083)