### PR TITLE
[C-20085] Edge case: Thomas's template link color not being applied

### DIFF
--- a/.changeset/link-bubble-front-and-default-colour.md
+++ b/.changeset/link-bubble-front-and-default-colour.md
@@ -1,0 +1,21 @@
+---
+"@trycourier/react-designer": patch
+---
+
+Two link fixes in the email editor.
+
+The link popover now sits above the text toolbar. Tippy puts its own `z-index: 9999` on the
+bubble menu root, so the popover's `z-50` left it drawn behind the toolbar whenever the two
+overlapped; it now renders at `z-[10000]`.
+
+Creating a link inside a coloured run no longer inherits that colour. The link range is split
+into its own `textStyle` run with the colour cleared, so the link renders in its default colour
+and picks up the block-level colour rather than the surrounding override. Editing an existing
+link — changing its URL or toggling link tracking — leaves the colour alone, so a colour picked
+from the text toolbar after the link exists still wins.
+
+Links also no longer render at their own font weight. Any global `a { font-weight: … }` a host
+ships beats plain inheritance on every link, and studio's legacy `ThemeWrapper` ships one at
+`500` — so a link inside an `h1` rendered lighter (500) than the heading around it (600). The
+editor's `a.link` rule now states `font-weight: inherit`, alongside the `color` and
+`text-decoration` it already pinned against that same global.

--- a/docs/summaries/handoff-2026-08-20-C-20085-execute.md
+++ b/docs/summaries/handoff-2026-08-20-C-20085-execute.md
@@ -1,0 +1,52 @@
+# Session Handoff: Link popover layering, link default colour, link font weight
+
+**Date:** 2026-08-20
+**Session Duration:** one session — implement in `courier-designer`, vendor into `frontend`
+**Session Focus:** C-20085 ("Edge case: Thomas's template link color not being applied"). Three link defects in the email editor, all reported from the same template.
+**Context Usage at Handoff:** low
+
+## What Was Accomplished
+
+1. **Link popover sits in front of the text toolbar** → `packages/react-designer/src/components/extensions/Link/LinkBubble.tsx`. Tippy stamps `z-index: 9999` on the bubble-menu root, so the popover's `courier-z-50` drew it behind the toolbar wherever the two overlapped. Now `courier-z-[10000]`.
+2. **A new link no longer inherits the surrounding run's colour** → same file plus `LinkForm.tsx` (the sidebar form). Creating a link now runs `unsetColor()` over the link range before `setLink`, so the range becomes its own `textStyle` run with `color: null` and the link renders in its default colour (`--brand-link-color`, falling back to `#007aff`). Gated on `!mark`: editing an existing link — URL change or link-tracking toggle — never touches the colour, so a colour picked from the text toolbar *after* the link exists still wins.
+3. **A link takes its font weight from the block it sits in** → `packages/react-designer/src/components/typography.css`. `.ProseMirror a.link` now states `font-weight: inherit`.
+4. Tests: `LinkColor.test.tsx` (4 cases, real editor + real `LinkBubble`), 4 new cases in `LinkBubble.test.tsx`, `typography.test.ts` (1 case). `unsetColor` added to the chain mocks in `LinkBubble.test.tsx` / `LinkForm.test.tsx`.
+5. `patch` changeset → `.changeset/link-bubble-front-and-default-colour.md`
+
+Branch `geraldosilva/c-20085-edge-case-thomass-template-link-color-not`, branched from `main` at `ec65d9fb`.
+
+## Exact State of Work in Progress
+
+Nothing mid-stream. The frontend side is a separate PR that vendors this branch's `dist`; see `docs/summaries/handoff-2026-08-20-C-20085-vendor.md` in `frontend`.
+
+## Decisions Made This Session
+
+**The font-weight bug was not a designer rule at all — it is a host global the designer has to defend against.** `packages/components/src/theme-wrapper.tsx:67` in `frontend` injects a global `a { color: #2a9edb; font-weight: 500; text-decoration: none }`. Any matching declaration beats an inherited value, so every editor link rendered at 500 while its `h1` stayed at 600. Measured in the running app: `a` → `500`, `h1` → `600`, `--email-editor-h1-font-weight` → `600`. Fixed in the designer rather than in the legacy `theme-wrapper` BECAUSE `.ProseMirror a.link` already pins `color` and `text-decoration` against that same global — weight was the one property missing — and because the designer must render the same in any host. Editing the legacy global would widen the blast radius across all of studio to fix a designer symptom.
+
+**Colour clearing is gated on link *creation*, not applied on every save.** The ticket asks for both halves: a new link starts from the link's default colour, and the author can still override it from the text toolbar afterwards. Those conflict if the colour is cleared on every write, because reopening the popover to change the URL (or flipping link tracking) would wipe the override. `!mark` distinguishes the two: no existing link mark means this is a creation.
+
+**`unsetColor` over `removeMark`.** It is the extension's own command (`Color.ts`), `setMark("textStyle", { color: null })` + `removeEmptyTextStyle`, so a co-located `fontSize` on the same `textStyle` mark survives the clear.
+
+**Brand-footer links keep their deliberate `font-normal`.** `BrandFooter.tsx` sets it through `[&_.ProseMirror_a]:courier-font-normal`, which ties with `.ProseMirror a.link` on specificity (0,2,1) and sits later in the built sheet (line 6552 vs 95), so it still wins. Verified in `dist/styles.css` after the build.
+
+## Key Numbers Generated or Discovered This Session
+
+- Link + typography suites: 85 pass, 0 fail. `npx tsc -p tsconfig.build.json` exit 0.
+- `eslint` clean on the touched source paths (`lint:src` excludes `*.test.*`).
+- Vendored stamp produced for `frontend`: `0.8.0-vendor.78478c572aec`.
+
+## Regression Cycle (per the repo's test rule)
+
+- Colour + z-index fixes rolled back → 4 tests fail (2 in `LinkBubble.test.tsx`, 2 in `LinkColor.test.tsx`); restored → 84/84 pass.
+- `font-weight: inherit` removed from `typography.css` → `typography.test.ts` fails; restored → passes.
+
+## Conditional Logic Established
+
+- IF a link is being created (no existing `link` mark on the range) THEN the range's inline colour is cleared before `setLink`.
+- IF a link already exists (URL edit, link-tracking toggle) THEN the colour is left exactly as it is.
+- IF a host ships a global `a { … }` rule THEN `.ProseMirror a.link` must state that property explicitly; inheritance alone loses.
+
+## Related
+
+- Frontend vendor PR handoff: `docs/summaries/handoff-2026-08-20-C-20085-vendor.md` in `frontend`
+- Linear: https://linear.app/trycourier/issue/C-20085

--- a/packages/react-designer/src/components/extensions/Link/LinkBubble.test.tsx
+++ b/packages/react-designer/src/components/extensions/Link/LinkBubble.test.tsx
@@ -21,6 +21,7 @@ const mockEditor = {
     focus: vi.fn().mockReturnThis(),
     unsetLink: vi.fn().mockReturnThis(),
     setTextSelection: vi.fn().mockReturnThis(),
+    unsetColor: vi.fn().mockReturnThis(),
     setLink: vi.fn().mockReturnThis(),
     run: vi.fn(),
   })),
@@ -183,6 +184,58 @@ describe("LinkBubble", () => {
     expect(windowOpen).toHaveBeenCalledWith("https://example.com", "_blank", "noopener,noreferrer");
 
     windowOpen.mockRestore();
+  });
+
+  describe("Link colour", () => {
+    const saveUrl = (url: string) => {
+      const input = screen.getByPlaceholderText("Paste a link...");
+      fireEvent.change(input, { target: { value: url } });
+      fireEvent.keyDown(input, { key: "Enter" });
+      return mockEditor.chain.mock.results.at(-1)?.value;
+    };
+
+    it("clears the inline text colour when creating a new link", () => {
+      renderWithStore({ link: { from: 1, to: 5 } });
+      const chain = saveUrl("https://test.com");
+
+      // The link range gets its own textStyle run with no colour, so the link
+      // renders in its default colour instead of inheriting the coloured run.
+      expect(chain.unsetColor).toHaveBeenCalled();
+      expect(chain.setLink).toHaveBeenCalledWith(
+        expect.objectContaining({ href: "https://test.com" })
+      );
+    });
+
+    it("keeps the colour when editing an existing link so a toolbar override sticks", () => {
+      renderWithStore({
+        link: { from: 1, to: 5 },
+        mark: { attrs: { href: "https://example.com", target: null } },
+      });
+      const chain = saveUrl("https://updated.com");
+
+      expect(chain.unsetColor).not.toHaveBeenCalled();
+      expect(chain.setLink).toHaveBeenCalledWith(
+        expect.objectContaining({ href: "https://updated.com" })
+      );
+    });
+
+    it("does not touch the colour when only toggling tracking on an existing link", () => {
+      renderWithStore({
+        link: { from: 1, to: 5 },
+        mark: { attrs: { href: "https://example.com", target: null } },
+      });
+
+      fireEvent.click(screen.getByRole("switch"));
+
+      const chain = mockEditor.chain.mock.results.at(-1)?.value;
+      expect(chain.unsetColor).not.toHaveBeenCalled();
+    });
+  });
+
+  it("renders above the text toolbar's tippy layer", () => {
+    const { container } = renderWithStore({ link: { from: 1, to: 5 } });
+    // tippy sets z-index: 9999 on its own root, so the bubble must outrank it.
+    expect(container.firstElementChild).toHaveClass("courier-z-[10000]");
   });
 
   describe("Link tracking toggle", () => {

--- a/packages/react-designer/src/components/extensions/Link/LinkBubble.tsx
+++ b/packages/react-designer/src/components/extensions/Link/LinkBubble.tsx
@@ -79,7 +79,15 @@ export const LinkBubble = () => {
         target: mark?.attrs.target || null,
         disableTracking,
       };
-      editor.chain().focus().unsetLink().setTextSelection({ from, to }).setLink(linkAttrs).run();
+      // A brand new link starts from the link's own default colour: drop any
+      // inline text colour on the range so the mark inherits the block colour
+      // instead of the surrounding run's override. Editing an existing link
+      // leaves the colour alone so a toolbar override made afterwards sticks.
+      const chain = editor.chain().focus().unsetLink().setTextSelection({ from, to });
+      if (!mark) {
+        chain.unsetColor();
+      }
+      chain.setLink(linkAttrs).run();
       editor.commands.setTextSelection(to);
     }
 
@@ -151,7 +159,8 @@ export const LinkBubble = () => {
   return (
     <div
       ref={containerRef}
-      className="courier-absolute courier-z-50"
+      // Above tippy's own 9999 so the bubble is never covered by the text toolbar.
+      className="courier-absolute courier-z-[10000]"
       style={{ top: position.top, left: position.left }}
     >
       <div

--- a/packages/react-designer/src/components/extensions/Link/LinkColor.test.tsx
+++ b/packages/react-designer/src/components/extensions/Link/LinkColor.test.tsx
@@ -1,0 +1,142 @@
+import { linkTrackingEnabledAtom } from "@/components/TemplateEditor/store";
+import { pendingLinkAtom } from "@/components/ui/TextMenu/store";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Document } from "@tiptap/extension-document";
+import { Paragraph } from "@tiptap/extension-paragraph";
+import { Text } from "@tiptap/extension-text";
+import { TextStyle } from "@tiptap/extension-text-style";
+import { Editor } from "@tiptap/react";
+import { Provider, createStore } from "jotai";
+import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Color } from "../Color/Color";
+import { Link } from "./Link";
+import { LinkBubble } from "./LinkBubble";
+
+let editor: Editor;
+
+vi.mock("@tiptap/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tiptap/react")>();
+  return { ...actual, useCurrentEditor: () => ({ editor }) };
+});
+
+/**
+ * End-to-end cover, against a real editor, for the colour handling on link
+ * creation: a link made inside an already-coloured run must become its own
+ * textStyle run with no colour so it renders in the link's default colour,
+ * while the surrounding text keeps the colour the user chose. A colour picked
+ * from the toolbar afterwards still overrides the link.
+ */
+describe("Link colour inheritance", () => {
+  let host: HTMLDivElement;
+
+  beforeEach(() => {
+    // LinkBubble positions itself against the email-editor container.
+    host = document.createElement("div");
+    host.setAttribute("data-testid", "email-editor");
+    document.body.appendChild(host);
+
+    editor = new Editor({
+      element: host,
+      extensions: [Document, Paragraph, Text, TextStyle, Color, Link],
+      content: "<p>Click here now</p>",
+    });
+
+    // jsdom has no layout, so ProseMirror cannot measure the selection the
+    // bubble anchors to. Any finite rect is enough for it to render.
+    vi.spyOn(editor.view, "coordsAtPos").mockReturnValue({
+      top: 0,
+      bottom: 10,
+      left: 0,
+      right: 10,
+    });
+  });
+
+  afterEach(() => {
+    editor.destroy();
+    host.remove();
+  });
+
+  /** Colour of the textStyle mark covering `pos`, or null when uncoloured. */
+  const colorAt = (pos: number) => {
+    const marks = editor.state.doc.resolve(pos).marks();
+    return marks.find((mark) => mark.type.name === "textStyle")?.attrs.color ?? null;
+  };
+
+  const hasLinkAt = (pos: number) =>
+    editor.state.doc
+      .resolve(pos)
+      .marks()
+      .some((mark) => mark.type.name === "link");
+
+  const markAt = (pos: number) =>
+    editor.state.doc
+      .resolve(pos)
+      .marks()
+      .find((mark) => mark.type.name === "link");
+
+  /** Render the bubble over `range`, type `url` and save it. */
+  const addLinkVia = (range: { from: number; to: number }, url: string) => {
+    const store = createStore();
+    store.set(pendingLinkAtom, { link: range, mark: markAt(range.from + 1) });
+    store.set(linkTrackingEnabledAtom, true);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      createElement(Provider, { store }, children);
+    const view = render(createElement(LinkBubble), { wrapper });
+
+    const input = screen.getByPlaceholderText("Paste a link...");
+    fireEvent.change(input, { target: { value: url } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    view.unmount();
+  };
+
+  it("splits a coloured run so the linked sub-string has no colour of its own", () => {
+    editor.chain().setTextSelection({ from: 1, to: 15 }).setColor("#ff0000").run();
+    expect(colorAt(2)).toBe("#ff0000");
+
+    // Link only "here", a sub-part of the coloured run.
+    addLinkVia({ from: 7, to: 11 }, "https://example.com");
+
+    expect(hasLinkAt(8)).toBe(true);
+    expect(colorAt(8)).toBeNull();
+    // Text on either side keeps the user's colour.
+    expect(colorAt(2)).toBe("#ff0000");
+    expect(colorAt(13)).toBe("#ff0000");
+    expect(hasLinkAt(2)).toBe(false);
+  });
+
+  it("drops the colour when the whole coloured block becomes the link", () => {
+    editor.chain().setTextSelection({ from: 1, to: 15 }).setColor("#123456").run();
+
+    addLinkVia({ from: 1, to: 15 }, "https://example.com");
+
+    expect(hasLinkAt(2)).toBe(true);
+    expect(colorAt(2)).toBeNull();
+  });
+
+  it("lets a colour applied after the link override the link's colour", () => {
+    editor.chain().setTextSelection({ from: 1, to: 15 }).setColor("#ff0000").run();
+    addLinkVia({ from: 7, to: 11 }, "https://example.com");
+
+    // Toolbar override on the link range, done after the link exists.
+    editor.chain().setTextSelection({ from: 7, to: 11 }).setColor("#00ff00").run();
+
+    expect(hasLinkAt(8)).toBe(true);
+    expect(colorAt(8)).toBe("#00ff00");
+    expect(colorAt(2)).toBe("#ff0000");
+  });
+
+  it("keeps a toolbar colour override when the link's URL is later edited", () => {
+    editor.chain().setTextSelection({ from: 1, to: 15 }).setColor("#ff0000").run();
+    addLinkVia({ from: 7, to: 11 }, "https://example.com");
+    editor.chain().setTextSelection({ from: 7, to: 11 }).setColor("#00ff00").run();
+
+    // Re-opening an existing link and changing the URL must not reset the colour.
+    addLinkVia({ from: 7, to: 11 }, "https://updated.com");
+
+    expect(markAt(8)?.attrs.href).toBe("https://updated.com");
+    expect(colorAt(8)).toBe("#00ff00");
+  });
+});

--- a/packages/react-designer/src/components/extensions/Link/LinkForm.test.tsx
+++ b/packages/react-designer/src/components/extensions/Link/LinkForm.test.tsx
@@ -40,6 +40,7 @@ describe("LinkForm", () => {
       focus: vi.fn().mockReturnThis(),
       unsetLink: vi.fn().mockReturnThis(),
       setTextSelection: vi.fn().mockReturnThis(),
+      unsetColor: vi.fn().mockReturnThis(),
       setLink: vi.fn().mockReturnThis(),
       run: vi.fn().mockReturnValue(true),
     };

--- a/packages/react-designer/src/components/extensions/Link/LinkForm.tsx
+++ b/packages/react-designer/src/components/extensions/Link/LinkForm.tsx
@@ -92,13 +92,19 @@ export const LinkForm = ({ editor, mark, pendingLink }: LinkFormProps) => {
       disableTracking: values.disableTracking,
     };
 
-    await editor
+    // A brand new link starts from the link's own default colour: drop any inline
+    // text colour on the range so the mark inherits the block colour instead of
+    // the surrounding run's override. Editing an existing link leaves the colour
+    // alone so a toolbar override made afterwards sticks.
+    const chain = editor
       ?.chain()
       .focus()
       .unsetLink()
-      .setTextSelection({ from: pendingLink?.from || 0, to: pendingLink?.to || 0 })
-      .setLink(linkAttrs)
-      .run();
+      .setTextSelection({ from: pendingLink?.from || 0, to: pendingLink?.to || 0 });
+    if (chain && !mark) {
+      chain.unsetColor();
+    }
+    await chain?.setLink(linkAttrs).run();
 
     // Remove text selection but keep focus by moving cursor to end of link
     editor?.commands.setTextSelection(pendingLink?.to || 0);

--- a/packages/react-designer/src/components/typography.css
+++ b/packages/react-designer/src/components/typography.css
@@ -59,6 +59,12 @@
        wins). The fallback is the product's default link blue, so a host that
        doesn't set the variable still gets the same blue studio shows. */
     color: var(--brand-link-color, #007aff);
+    /* A link takes its weight from the block it sits in — nothing in the editor
+       gives links a weight of their own. Stated explicitly because a host's
+       global `a { font-weight: … }` (studio's legacy ThemeWrapper ships one at
+       500) beats plain inheritance on every matching link, which showed up as a
+       link inside an h1 rendering lighter than the heading around it. */
+    font-weight: inherit;
   }
 
   mark {

--- a/packages/react-designer/src/components/typography.test.ts
+++ b/packages/react-designer/src/components/typography.test.ts
@@ -1,0 +1,33 @@
+import * as fs from "fs";
+import * as path from "path";
+import { describe, expect, it } from "vitest";
+
+// Comments are stripped first: the ones in this rule quote CSS, braces included,
+// so a naive scan for the closing brace would stop inside a comment.
+const css = fs
+  .readFileSync(path.join(__dirname, "typography.css"), "utf-8")
+  .replace(/\/\*[\s\S]*?\*\//g, "");
+
+/** The declarations inside the `a.link` block. */
+const linkBlock = (() => {
+  const start = css.indexOf("a.link {");
+  if (start === -1) throw new Error("a.link rule not found in typography.css");
+  const end = css.indexOf("}", start);
+  return css.slice(start, end);
+})();
+
+describe("typography.css a.link", () => {
+  /**
+   * A host's global `a { … }` rule beats inheritance on every link in the
+   * editor, because any matching declaration wins over an inherited value.
+   * Studio's legacy ThemeWrapper ships `a { color: #2a9edb; font-weight: 500;
+   * text-decoration: none }`, so each of those three properties has to be
+   * stated here or the editor renders the host's value — which is how a link
+   * inside an h1 ended up lighter (500) than the heading around it (600).
+   */
+  it("states every property studio's global anchor rule sets", () => {
+    expect(linkBlock).toMatch(/font-weight:\s*inherit/);
+    expect(linkBlock).toMatch(/color:\s*var\(--brand-link-color/);
+    expect(linkBlock).toMatch(/courier-no-underline/);
+  });
+});


### PR DESCRIPTION
## What

Three link defects in the email editor, all reported from the same template.

- **Link popover drew behind the text toolbar** wherever the two overlapped. Tippy stamps `z-index: 9999` on the bubble-menu root, so the popover's `z-50` never stood a chance; it now renders at `z-[10000]`.
- **Creating a link inside a coloured run inherited that colour**, so the link never read as a link. Link creation now clears the inline colour over the link range (`unsetColor` before `setLink`), splitting it into its own `textStyle` run so the link renders in its default colour (`--brand-link-color`, fallback `#007aff`). Editing an existing link — URL change, link-tracking toggle — deliberately leaves the colour alone, so a colour picked from the text toolbar *after* the link exists still wins.
- **A link inside an `h1` rendered lighter (500) than the heading around it (600).** That weight comes from a host global: studio's legacy `ThemeWrapper` ships `a { color: #2a9edb; font-weight: 500; text-decoration: none }`, and a matching declaration beats an inherited value on every link in the editor. `.ProseMirror a.link` already pinned that rule's `color` and `text-decoration`; it now states `font-weight: inherit` too.

Brand-footer links keep their deliberate `font-normal` — `[&_.ProseMirror_a]:courier-font-normal` ties on specificity and sits later in the built sheet (line 6552 vs 95), verified in `dist/styles.css`.

## Tests

85 pass across the link + typography suites, `tsc -p tsconfig.build.json` exit 0. New: `LinkColor.test.tsx` (4 cases, real editor driving the real `LinkBubble`), 4 cases in `LinkBubble.test.tsx`, `typography.test.ts` (1 case).

Regression cycle per the repo rule: colour + z-index fixes rolled back → 4 tests fail; `font-weight: inherit` removed → `typography.test.ts` fails; both restored → all green.

## Linear

C-20085: Edge case: Thomas's template link color not being applied
https://linear.app/trycourier/issue/C-20085

## ADRs

None

## Open Items

The frontend side is a separate PR that vendors this branch's `dist`.